### PR TITLE
Fix IconSearch import path to use @ alias

### DIFF
--- a/src/app/AppViewSwitcher.tsx
+++ b/src/app/AppViewSwitcher.tsx
@@ -1,6 +1,6 @@
 import Switcher from '@/components/Switcher';
 import SwitcherItem from '@/components/SwitcherItem';
-import IconSearch from '../components/icons/IconSearch';
+import IconSearch from '@/components/icons/IconSearch';
 import { useAppState } from '@/state/AppState';
 import {
   SHOW_KEYBOARD_SHORTCUT_TOOLTIPS,


### PR DESCRIPTION
Changed relative import '../components/icons/IconSearch' to absolute import '@/components/icons/IconSearch' for consistency with other imports and to resolve build errors after merge.