### PR TITLE
feat: Integrate full wiki system into provider edit form

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -6,7 +6,7 @@ export default async function AdminLayout({
   children: React.ReactNode
 }) {
   return (
-    <div className="mt-4 space-y-4">
+    <div className="mt-4 space-y-4 font-admin">
       <AdminNav />
       {children}
     </div>

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-tooltip": "^1.2.7",
     "@radix-ui/react-visually-hidden": "^1.2.3",
+    "@tailwindcss/typography": "^0.5.19",
     "@tiptap/core": "^3.10.5",
     "@tiptap/extension-color": "^3.10.5",
     "@tiptap/extension-highlight": "^3.10.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@radix-ui/react-visually-hidden':
         specifier: ^1.2.3
         version: 1.2.4(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@tailwindcss/typography':
+        specifier: ^0.5.19
+        version: 0.5.19(tailwindcss@4.1.7)
       '@tiptap/core':
         specifier: ^3.10.5
         version: 3.10.5(@tiptap/pm@3.10.5)
@@ -1392,6 +1395,11 @@ packages:
   '@tailwindcss/postcss@4.1.17':
     resolution: {integrity: sha512-+nKl9N9mN5uJ+M7dBOOCzINw94MPstNR/GtIhz1fpZysxL/4a+No64jCBD6CPN+bIHWFx3KWuu8XJRrj/572Dw==}
 
+  '@tailwindcss/typography@0.5.19':
+    resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
+
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
@@ -2276,6 +2284,11 @@ packages:
 
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   cssom@0.3.8:
     resolution: {integrity: sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==}
@@ -3775,6 +3788,10 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
+
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -4440,6 +4457,9 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
@@ -5765,6 +5785,11 @@ snapshots:
       postcss: 8.5.3
       tailwindcss: 4.1.17
 
+  '@tailwindcss/typography@0.5.19(tailwindcss@4.1.7)':
+    dependencies:
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 4.1.7
+
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -6712,6 +6737,8 @@ snapshots:
       which: 2.0.2
 
   css.escape@1.5.1: {}
+
+  cssesc@3.0.0: {}
 
   cssom@0.3.8: {}
 
@@ -8486,6 +8513,11 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.11
@@ -9261,6 +9293,8 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.1.0):
     dependencies:
       react: 19.1.0
+
+  util-deprecate@1.0.2: {}
 
   v8-compile-cache-lib@3.0.1: {}
 

--- a/src/provider/actions.ts
+++ b/src/provider/actions.ts
@@ -225,6 +225,9 @@ export async function updateProvider(
         ...(data.preferences !== undefined && {
           preferences: data.preferences,
         }),
+        ...(data.wikiContent !== undefined && {
+          wikiContent: data.wikiContent,
+        }),
       },
     });
 

--- a/tailwind.css
+++ b/tailwind.css
@@ -2,6 +2,7 @@
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap");
 
 @import 'tailwindcss';
+@plugin '@tailwindcss/typography';
 
 @import './src/css/sonner.css';
 @import './src/css/viewerjs.css';
@@ -18,6 +19,7 @@
 
 @theme {
   --font-mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  --font-admin: Calibri, 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 
   --breakpoint-xs: 24.5rem;
   --breakpoint-3xl: 102rem;
@@ -224,6 +226,11 @@
 /* Typing Trainer Utilities */
 @utility font-typing {
   font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+}
+
+/* Admin Interface Utilities */
+@utility font-admin {
+  font-family: Calibri, 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 }
 
 @layer base {


### PR DESCRIPTION
Major changes:
- Fixed wiki save bug by adding wikiContent field to updateProvider action
- Installed @tailwindcss/typography for proper rich text styling
- Added Calibri font to admin interface for better readability
- Integrated full wiki system (SectionManager + MediaLibrary) into provider form
- Moved Note SmartPhrase above Provider Documentation section
- Provider Documentation now uses tabbed interface (Sections/Media)
- Added wiki content state management and handlers
- Updated form submission to include wiki metadata

Technical details:
- Added WikiContent state with createEmptyWikiContent
- Added handleUploadComplete and handleDeleteMedia handlers
- Updated handleEdit to load wiki content from provider
- Updated handleSubmit to save wiki content with metadata
- Updated resetRichTextFields to reset wiki content
- Removed noteTemplate in favor of full wiki system
- Added activeWikiTab state for tab switching

This allows editing provider wiki content directly in the main form instead of requiring a separate wiki editor page.