### PR TITLE
fix: Resolve provider update failures and improve error handling

### DIFF
--- a/app/admin/providers/ProvidersClient.tsx
+++ b/app/admin/providers/ProvidersClient.tsx
@@ -71,10 +71,15 @@ export default function ProvidersClient({
       },
     };
 
+    // Helper to convert empty strings to undefined
+    const getStringOrUndefined = (value: string | null): string | undefined => {
+      return value && value.trim() !== '' ? value : undefined;
+    };
+
     const data: ProviderFormData = {
       name: formData.get('name') as string,
       slug: formData.get('slug') as string,
-      credentials: formData.get('credentials') as string,
+      credentials: getStringOrUndefined(formData.get('credentials') as string),
       noteSmartPhrase: JSON.stringify(noteSmartPhrase),
       wikiContent: updatedWikiContent as any,
       generalDifficulty,
@@ -82,6 +87,8 @@ export default function ProvidersClient({
       terminologyDifficulty,
       noteDifficulty,
     };
+
+    console.log('Submitting provider data:', data);
 
     try {
       const result = editingProvider
@@ -101,10 +108,11 @@ export default function ProvidersClient({
         router.refresh();
       } else {
         toast.error(result.error || 'An error occurred');
+        console.error('Server returned error:', result.error);
       }
     } catch (error) {
       toast.error('An unexpected error occurred');
-      console.error(error);
+      console.error('Submit error:', error);
     } finally {
       setIsSubmitting(false);
     }

--- a/src/provider/actions.ts
+++ b/src/provider/actions.ts
@@ -157,6 +157,7 @@ export async function createProvider(
         noteTemplate: data.noteTemplate || null,
         noteSmartPhrase: data.noteSmartPhrase || null,
         ...(data.preferences && { preferences: data.preferences }),
+        ...(data.wikiContent && { wikiContent: data.wikiContent }),
       },
     });
 
@@ -167,7 +168,8 @@ export async function createProvider(
     return { success: true, provider };
   } catch (error) {
     console.error('Error creating provider:', error);
-    return { success: false, error: 'Failed to create provider' };
+    const errorMessage = error instanceof Error ? error.message : 'Failed to create provider';
+    return { success: false, error: `Failed to create provider: ${errorMessage}` };
   }
 }
 
@@ -238,7 +240,9 @@ export async function updateProvider(
     return { success: true, provider };
   } catch (error) {
     console.error('Error updating provider:', error);
-    return { success: false, error: 'Failed to update provider' };
+    // Return more specific error message if available
+    const errorMessage = error instanceof Error ? error.message : 'Failed to update provider';
+    return { success: false, error: `Failed to update provider: ${errorMessage}` };
   }
 }
 


### PR DESCRIPTION
Critical fixes for update provider functionality:

1. Fixed credentials field handling:
   - Convert empty credentials string to undefined instead of passing empty string
   - Added getStringOrUndefined helper function to handle empty form fields
   - Prevents database constraint violations with empty strings

2. Added wikiContent to createProvider:
   - Previously missing from provider creation
   - Now properly saves wiki content when creating new providers

3. Improved error logging and messages:
   - Added console.log for submitted data to help debug issues
   - Enhanced error messages to include actual error details
   - Changed generic "Failed to update provider" to include specific error message
   - Added error logging on both client and server side

4. Better error handling:
   - Server actions now return specific error messages
   - Client-side logging shows both server errors and submission errors
   - Error messages visible in browser console for debugging

This should resolve the "Failed to update provider" error by properly handling empty form fields and providing better visibility into any remaining issues.