### PR TITLE
fix: Serialize WikiContent to prevent client reference errors

### DIFF
--- a/app/admin/providers/ProvidersClient.tsx
+++ b/app/admin/providers/ProvidersClient.tsx
@@ -76,12 +76,15 @@ export default function ProvidersClient({
       return value && value.trim() !== '' ? value : undefined;
     };
 
+    // Serialize wikiContent to ensure it's plain JSON without client references
+    const serializedWikiContent = JSON.parse(JSON.stringify(updatedWikiContent));
+
     const data: ProviderFormData = {
       name: formData.get('name') as string,
       slug: formData.get('slug') as string,
       credentials: getStringOrUndefined(formData.get('credentials') as string),
       noteSmartPhrase: JSON.stringify(noteSmartPhrase),
-      wikiContent: updatedWikiContent as any,
+      wikiContent: serializedWikiContent,
       generalDifficulty,
       speedDifficulty,
       terminologyDifficulty,


### PR DESCRIPTION
Critical fix for Next.js 15 server action compatibility:

The error "Cannot access toStringTag on the server" was caused by passing WikiContent objects containing Tiptap JSONContent (with client-side references) directly to server actions.

Solution:
- Added JSON.parse(JSON.stringify()) serialization step
- Strips client-side references before sending to server
- Ensures only plain JSON-serializable data is transmitted
- Maintains all wiki content data integrity

This fixes the "Failed to update provider" error when trying to save providers with wiki content.

Error details:
"Cannot access toStringTag on the server. You cannot dot into a temporary client reference from a server component. You can only pass the value through to the client."