### PR TITLE
fix: Update type imports to use action files instead of Prisma client

### DIFF
--- a/app/admin/procedures/ProceduresAdminClient.tsx
+++ b/app/admin/procedures/ProceduresAdminClient.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { Procedure } from '@prisma/client';
 import {
+  Procedure,
   createProcedure,
   updateProcedure,
   deleteProcedure,

--- a/app/admin/scenarios/ScenariosAdminClient.tsx
+++ b/app/admin/scenarios/ScenariosAdminClient.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { Scenario } from '@prisma/client';
 import {
+  Scenario,
   createScenario,
   updateScenario,
   deleteScenario,

--- a/app/admin/smartphrases/SmartPhrasesAdminClient.tsx
+++ b/app/admin/smartphrases/SmartPhrasesAdminClient.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { SmartPhrase } from '@prisma/client';
 import {
+  SmartPhrase,
   createSmartPhrase,
   updateSmartPhrase,
   deleteSmartPhrase,

--- a/app/procedures/ProceduresPageClient.tsx
+++ b/app/procedures/ProceduresPageClient.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { useState, useMemo } from 'react';
-import { Procedure } from '@prisma/client';
-import { incrementProcedureViewCount } from '@/procedure/actions';
+import { Procedure, incrementProcedureViewCount } from '@/procedure/actions';
 import {
   FiSearch,
   FiChevronDown,

--- a/app/scenarios/ScenariosPageClient.tsx
+++ b/app/scenarios/ScenariosPageClient.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { useState, useMemo } from 'react';
-import { Scenario } from '@prisma/client';
-import { incrementScenarioViewCount } from '@/scenario/actions';
+import { Scenario, incrementScenarioViewCount } from '@/scenario/actions';
 import {
   FiSearch,
   FiChevronDown,

--- a/app/smartphrases/SmartPhrasesPageClient.tsx
+++ b/app/smartphrases/SmartPhrasesPageClient.tsx
@@ -1,9 +1,8 @@
 'use client';
 
 import { useState, useMemo } from 'react';
-import { SmartPhrase } from '@prisma/client';
 import { toast } from 'sonner';
-import { incrementSmartPhraseUsage } from '@/smartphrase/actions';
+import { SmartPhrase, incrementSmartPhraseUsage } from '@/smartphrase/actions';
 import {
   FiSearch,
   FiCopy,


### PR DESCRIPTION
All SmartPhrase, Scenario, and Procedure UI components were importing types from '@prisma/client', but these types don't exist in the generated Prisma client because it couldn't regenerate in the sandboxed environment.

Changes:
- Updated all 6 UI files to import types from action files
- SmartPhrasesAdminClient.tsx: import SmartPhrase from actions
- SmartPhrasesPageClient.tsx: import SmartPhrase from actions
- ScenariosAdminClient.tsx: import Scenario from actions
- ScenariosPageClient.tsx: import Scenario from actions
- ProceduresAdminClient.tsx: import Procedure from actions
- ProceduresPageClient.tsx: import Procedure from actions

This fixes TypeScript compilation errors and ensures the UI can properly type-check against the SQL-based action implementations.