### PR TITLE
fix: Support multiple database URL environment variables

### DIFF
--- a/app/api/admin/diagnostics/route.ts
+++ b/app/api/admin/diagnostics/route.ts
@@ -21,14 +21,26 @@ export async function GET(request: NextRequest) {
       NODE_ENV: process.env.NODE_ENV,
     };
 
-    if (!process.env.DATABASE_URL) {
-      diagnostics.errors.push('DATABASE_URL environment variable is not set');
+    // Use any available database URL
+    const databaseUrl =
+      process.env.DATABASE_URL ||
+      process.env.POSTGRES_URL ||
+      process.env.PRISMA_DATABASE_URL;
+
+    if (!databaseUrl) {
+      diagnostics.errors.push('No database URL found (checked DATABASE_URL, POSTGRES_URL, PRISMA_DATABASE_URL)');
       return NextResponse.json(diagnostics, { status: 500 });
     }
 
+    // Log which one is being used
+    const envVarUsed = process.env.DATABASE_URL ? 'DATABASE_URL' :
+                       process.env.POSTGRES_URL ? 'POSTGRES_URL' :
+                       'PRISMA_DATABASE_URL';
+    diagnostics.environment.using = `✓ Using ${envVarUsed}`;
+
     // Try to connect to database
     const pool = new Pool({
-      connectionString: process.env.DATABASE_URL,
+      connectionString: databaseUrl,
       connectionTimeoutMillis: 5000,
     });
 

--- a/scripts/run-migrations.js
+++ b/scripts/run-migrations.js
@@ -129,20 +129,31 @@ async function runMigrations() {
   console.log('🔄 MIGRATION SCRIPT STARTED');
   console.log('========================================\n');
 
-  // Check for DATABASE_URL
-  if (!process.env.DATABASE_URL) {
-    console.error('❌ CRITICAL: DATABASE_URL environment variable is not set!');
+  // Check for database URL (try multiple env vars)
+  const databaseUrl =
+    process.env.DATABASE_URL ||
+    process.env.POSTGRES_URL ||
+    process.env.PRISMA_DATABASE_URL;
+
+  if (!databaseUrl) {
+    console.error('❌ CRITICAL: No database URL found!');
+    console.log('Checked: DATABASE_URL, POSTGRES_URL, PRISMA_DATABASE_URL');
     console.log('Available env vars:', Object.keys(process.env).filter(k => k.includes('DATABASE') || k.includes('POSTGRES')));
     console.log('\n⚠️  Skipping migrations - database tables will NOT be created');
     console.log('========================================\n');
     return;
   }
 
-  console.log('✓ DATABASE_URL found');
-  console.log('  Connection string:', process.env.DATABASE_URL.replace(/:[^:@]+@/, ':****@')); // Hide password
+  // Log which env var was used
+  const envVarUsed = process.env.DATABASE_URL ? 'DATABASE_URL' :
+                     process.env.POSTGRES_URL ? 'POSTGRES_URL' :
+                     'PRISMA_DATABASE_URL';
+
+  console.log(`✓ Using ${envVarUsed}`);
+  console.log('  Connection string:', databaseUrl.replace(/:[^:@]+@/, ':****@')); // Hide password
 
   const pool = new Pool({
-    connectionString: process.env.DATABASE_URL,
+    connectionString: databaseUrl,
     connectionTimeoutMillis: 10000,
   });
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -4,10 +4,25 @@ import { Pool } from 'pg';
 // This is used for models that can't use Prisma due to client generation issues
 let pool: Pool | null = null;
 
+// Get database URL from any available environment variable
+function getDatabaseUrl(): string | undefined {
+  return (
+    process.env.DATABASE_URL ||
+    process.env.POSTGRES_URL ||
+    process.env.PRISMA_DATABASE_URL
+  );
+}
+
 export function getPool(): Pool {
   if (!pool) {
+    const connectionString = getDatabaseUrl();
+    if (!connectionString) {
+      throw new Error(
+        'No database URL found. Set DATABASE_URL, POSTGRES_URL, or PRISMA_DATABASE_URL'
+      );
+    }
     pool = new Pool({
-      connectionString: process.env.DATABASE_URL,
+      connectionString,
       // Connection pool settings
       max: 20,
       idleTimeoutMillis: 30000,


### PR DESCRIPTION
The migration script was only checking DATABASE_URL, but Vercel and other platforms set POSTGRES_URL or PRISMA_DATABASE_URL instead. This caused migrations to silently skip, leaving SmartPhrase, Scenario, and Procedure tables uncreated.

Changes:
- Updated migration script to check DATABASE_URL, POSTGRES_URL, and PRISMA_DATABASE_URL
- Updated src/lib/db.ts to use any available database URL
- Updated diagnostics API to show which env var is being used
- Added logging to show which database URL env var was found

This fixes the issue where Provider table exists (created via old Prisma migrations) but new tables don't exist (because automatic migrations weren't running due to missing DATABASE_URL).

Now migrations will run automatically using whichever database URL is available.