### PR TITLE
fix: Run migrations via Next.js instrumentation on server startup

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,23 @@
+// This file runs when the Next.js server starts up
+// It's the proper place to run database migrations in Next.js 15+
+// Docs: https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation
+
+export async function register() {
+  // Only run on the server, not in the browser or during build
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    console.log('\n🚀 Next.js Instrumentation: Server starting...');
+
+    // Import the migration function dynamically to avoid build-time execution
+    const { runMigrations } = await import('./scripts/run-migrations.js');
+
+    try {
+      await runMigrations();
+    } catch (error) {
+      console.error('⚠️  Failed to run migrations during server startup:', error);
+      // Don't throw - allow the server to start even if migrations fail
+      // This prevents the app from crashing if there's a temporary DB issue
+    }
+
+    console.log('✅ Server initialization complete\n');
+  }
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -41,6 +41,8 @@ if (HOSTNAME_AWS_S3) {
 }
 
 const nextConfig: NextConfig = {
+  // Enable instrumentation hook for server startup tasks (like migrations)
+  instrumentationHook: true,
   eslint: {
     // Warning: This allows production builds to successfully complete even if
     // your project has ESLint errors.

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,4 @@
 {
-  "buildCommand": "pnpm build",
   "installCommand": "pnpm install --frozen-lockfile",
   "framework": "nextjs",
   "regions": ["iad1"],


### PR DESCRIPTION
PROBLEM:
- Migrations were not running in production despite DATABASE_URL being set
- vercel.json had "buildCommand": "pnpm build" which bypassed "vercel-build" script
- Migrations never executed, leaving SmartPhrase/Scenario/Procedure tables uncreated
- Provider table existed from old Prisma migrations (ran before this issue)

ROOT CAUSE:
Vercel was running "pnpm build" directly instead of the "vercel-build" script that included migrations. Additionally, DATABASE_URL may not be available during build phase (it's a runtime secret).

SOLUTION:
Use Next.js 15 instrumentation hook to run migrations when server starts:

1. Created instrumentation.ts
   - Runs automatically when Next.js server starts in production
   - Calls runMigrations() before handling any requests
   - Only runs on server-side (NEXT_RUNTIME === 'nodejs')
   - Gracefully handles errors without crashing the server

2. Updated next.config.ts
   - Enabled instrumentationHook: true
   - Allows Next.js to run instrumentation.ts on startup

3. Updated vercel.json
   - Removed custom "buildCommand" override
   - Lets Vercel use default Next.js build process
   - Migrations run at runtime when server starts (not during build)