### PR TITLE
feat: Improve page display and font consistency

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -6,7 +6,7 @@ export default async function AdminLayout({
   children: React.ReactNode
 }) {
   return (
-    <div className="mt-4 space-y-4 font-admin">
+    <div className="mt-4 space-y-4">
       <AdminNav />
       {children}
     </div>

--- a/src/components/workspace/WorkspaceSidebarClient.tsx
+++ b/src/components/workspace/WorkspaceSidebarClient.tsx
@@ -5,18 +5,14 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { clsx } from 'clsx/lite';
 import {
-  ChevronRight,
-  ChevronDown,
   FileText,
   Menu,
   X,
 } from 'lucide-react';
-import DraggablePageTree from '@/components/workspace/DraggablePageTree';
 
 export function WorkspaceSidebar() {
   const [isOpen, setIsOpen] = useState(true);
   const [isMobileOpen, setIsMobileOpen] = useState(false);
-  const [showPages, setShowPages] = useState(true);
   const pathname = usePathname();
 
   const isActive = (path: string) => pathname === path || pathname?.startsWith(path + '/');
@@ -95,27 +91,6 @@ export function WorkspaceSidebar() {
         >
           <span>Scenarios</span>
         </Link>
-      </div>
-
-      {/* Page Tree Section */}
-      <div className="mt-4">
-        <button
-          onClick={() => setShowPages(!showPages)}
-          className="w-full flex items-center justify-between px-3 py-2 text-xs font-medium text-dim hover:text-main transition-all border-b-2 border-transparent hover:border-white/30 dark:hover:border-white/30 hover-glow"
-        >
-          <span>PAGES</span>
-          {showPages ? (
-            <ChevronDown size={14} />
-          ) : (
-            <ChevronRight size={14} />
-          )}
-        </button>
-
-        {showPages && (
-          <div className="max-h-96 overflow-y-auto">
-            <DraggablePageTree />
-          </div>
-        )}
       </div>
     </div>
   );

--- a/tailwind.css
+++ b/tailwind.css
@@ -337,7 +337,7 @@
       border rounded-md
       bg-main
       border-gray-200 dark:border-gray-700
-      font-mono text-base leading-tight
+      font-sans text-base leading-tight
   }
   input[type=text], input[type=email], input[type=password], select, textarea {
     @apply
@@ -364,7 +364,7 @@
   }
   input[type=file] {
     @apply
-      block font-mono w-full text-medium
+      block font-sans w-full text-medium
       file:bg-white dark:file:bg-gray-950
       file:mr-2 file:my-2 file:px-4 file:py-1.5 file:rounded-md
       file:border-solid file:border


### PR DESCRIPTION
- Fix page content display to parse old wiki format and extract TipTap content
- Remove page header with edit button (admin-only access)
- Remove PAGES dropdown from sidebar (users access via providers/procedures/etc)
- Apply Mona Sans font to entire site except nav title and footer
- Remove Calibri font from admin pages
- Change form elements from monospace to Mona Sans

Pages now properly render content instead of showing raw JSON.