### PR TITLE
fix: Delete associated Page records when deleting providers/procedure…

### DIFF
--- a/src/procedure/actions.ts
+++ b/src/procedure/actions.ts
@@ -351,6 +351,12 @@ export async function deleteProcedure(
       return { success: false, error: check.error };
     }
 
+    // Delete associated Page records first using Prisma
+    await prisma.page.deleteMany({
+      where: { procedureId: id },
+    });
+
+    // Then delete the procedure
     await query(`DELETE FROM "Procedure" WHERE id = $1`, [id]);
 
     revalidatePath('/procedures');

--- a/src/provider/actions.ts
+++ b/src/provider/actions.ts
@@ -287,8 +287,17 @@ export async function deleteProvider(
   id: string,
 ): Promise<{ success: boolean; error?: string }> {
   try {
-    await prisma.provider.delete({
-      where: { id },
+    // Delete provider and associated page in a transaction
+    await prisma.$transaction(async (tx) => {
+      // Delete associated Page records first
+      await tx.page.deleteMany({
+        where: { providerId: id },
+      });
+
+      // Then delete the provider
+      await tx.provider.delete({
+        where: { id },
+      });
     });
 
     revalidatePath('/admin/providers');

--- a/src/scenario/actions.ts
+++ b/src/scenario/actions.ts
@@ -330,6 +330,12 @@ export async function deleteScenario(
       return { success: false, error: check.error };
     }
 
+    // Delete associated Page records first using Prisma
+    await prisma.page.deleteMany({
+      where: { scenarioId: id },
+    });
+
+    // Then delete the scenario
     await query(`DELETE FROM "Scenario" WHERE id = $1`, [id]);
 
     revalidatePath('/scenarios');

--- a/src/smartphrase/actions.ts
+++ b/src/smartphrase/actions.ts
@@ -330,6 +330,12 @@ export async function deleteSmartPhrase(
       return { success: false, error: check.error };
     }
 
+    // Delete associated Page records first using Prisma
+    await prisma.page.deleteMany({
+      where: { smartPhraseId: id },
+    });
+
+    // Then delete the smartphrase
     await query(`DELETE FROM "SmartPhrase" WHERE id = $1`, [id]);
 
     revalidatePath('/smartphrases');


### PR DESCRIPTION
…s/smartphrases/scenarios

This ensures that when an item is deleted, its corresponding Page record is also removed, preventing unique constraint errors when creating new items with the same slug as previously deleted items.

- Updated deleteProvider to use Prisma transaction for atomic deletion
- Updated deleteProcedure, deleteSmartPhrase, deleteScenario to delete Pages first
- Prevents orphaned Page records that cause slug conflicts