### PR TITLE
fix: Resolve TypeScript error in migration script and improve provide…

### DIFF
--- a/scripts/sync-provider-wiki-to-pages.ts
+++ b/scripts/sync-provider-wiki-to-pages.ts
@@ -1,0 +1,133 @@
+/**
+ * Migration Script: Sync Provider Wiki Content to Page Records
+ *
+ * This script synchronizes existing provider wikiContent to their associated Page records.
+ * Run this once after deploying the updateProvider fix.
+ *
+ * Usage: npx tsx scripts/sync-provider-wiki-to-pages.ts
+ */
+
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+interface WikiContent {
+  sections?: Array<{
+    id: string;
+    type: string;
+    visible: boolean;
+    content?: {
+      type: string;
+      content?: any[];
+    };
+  }>;
+}
+
+async function syncProviderWikiToPages() {
+  console.log('🔄 Starting provider wiki content sync...\n');
+
+  try {
+    // Fetch all providers (we'll filter in application code)
+    const providers = await prisma.provider.findMany({
+      include: {
+        page: true,
+      },
+    });
+
+    // Filter to only those with wikiContent
+    const providersWithWiki = providers.filter(p => p.wikiContent != null);
+
+    console.log(`Found ${providersWithWiki.length} providers with wiki content to sync\n`);
+
+    let syncedCount = 0;
+    let skippedCount = 0;
+    let errorCount = 0;
+
+    for (const provider of providersWithWiki) {
+      try {
+        const wikiContent = provider.wikiContent as WikiContent;
+
+        // Extract and combine all visible section content
+        const visibleSections = wikiContent.sections?.filter(s => s.visible) || [];
+
+        let combinedContent: any = {
+          type: 'doc',
+          content: [],
+        };
+
+        if (visibleSections.length > 0) {
+          // Combine all visible sections into one document
+          for (const section of visibleSections) {
+            if (section.content?.content) {
+              combinedContent.content.push(...section.content.content);
+            }
+          }
+        }
+
+        // If no content, use empty paragraph
+        if (combinedContent.content.length === 0) {
+          combinedContent.content = [{ type: 'paragraph', content: [] }];
+        }
+
+        // Update or create the associated Page record
+        if (provider.page) {
+          await prisma.page.update({
+            where: { id: provider.page.id },
+            data: {
+              content: combinedContent,
+              title: provider.name,
+              slug: provider.slug,
+            },
+          });
+          console.log(`✅ Synced: ${provider.name} (${provider.slug})`);
+          syncedCount++;
+        } else {
+          // Create a new Page if it doesn't exist
+          await prisma.page.create({
+            data: {
+              slug: provider.slug,
+              title: provider.name,
+              content: combinedContent,
+              type: 'PROVIDER',
+              providerId: provider.id,
+              position: 'a0',
+            },
+          });
+          console.log(`✅ Created page: ${provider.name} (${provider.slug})`);
+          syncedCount++;
+        }
+      } catch (error) {
+        console.error(`❌ Error syncing ${provider.name}:`, error);
+        errorCount++;
+      }
+    }
+
+    console.log('\n' + '='.repeat(50));
+    console.log('📊 Sync Summary:');
+    console.log(`   ✅ Synced: ${syncedCount}`);
+    console.log(`   ⏭️  Skipped: ${skippedCount}`);
+    console.log(`   ❌ Errors: ${errorCount}`);
+    console.log('='.repeat(50));
+
+    if (errorCount === 0) {
+      console.log('\n🎉 Migration completed successfully!');
+    } else {
+      console.log('\n⚠️  Migration completed with errors. Please review above.');
+    }
+  } catch (error) {
+    console.error('❌ Fatal error during migration:', error);
+    process.exit(1);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+// Run the migration
+syncProviderWikiToPages()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.error('Unhandled error:', error);
+    process.exit(1);
+  });

--- a/src/components/workspace/PageViewer.tsx
+++ b/src/components/workspace/PageViewer.tsx
@@ -13,6 +13,7 @@ import {
   Share2,
 } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
+import { EditorRenderer } from '@/components/editor/EditorRenderer';
 
 interface PageViewerProps {
   page: any; // TODO: Type this properly
@@ -21,43 +22,6 @@ interface PageViewerProps {
 export function PageViewer({ page }: PageViewerProps) {
   const router = useRouter();
   const [isEditing, setIsEditing] = useState(false);
-
-  // Render TipTap content (simplified version)
-  const renderContent = (content: any) => {
-    if (!content || !content.content) {
-      return <p className="text-dim">No content yet. Click Edit to add content.</p>;
-    }
-
-    // Simple rendering - would be replaced with actual TipTap renderer
-    return (
-      <div className="prose prose-lg dark:prose-invert max-w-none">
-        {content.content.map((node: any, i: number) => {
-          if (node.type === 'paragraph') {
-            return (
-              <p key={i}>
-                {node.content?.map((textNode: any) => textNode.text).join('')}
-              </p>
-            );
-          }
-          if (node.type === 'heading') {
-            const level = node.attrs.level;
-            const text = node.content?.map((textNode: any) => textNode.text).join('');
-
-            switch (level) {
-              case 1: return <h1 key={i}>{text}</h1>;
-              case 2: return <h2 key={i}>{text}</h2>;
-              case 3: return <h3 key={i}>{text}</h3>;
-              case 4: return <h4 key={i}>{text}</h4>;
-              case 5: return <h5 key={i}>{text}</h5>;
-              case 6: return <h6 key={i}>{text}</h6>;
-              default: return <p key={i}>{text}</p>;
-            }
-          }
-          return null;
-        })}
-      </div>
-    );
-  };
 
   return (
     <div className="max-w-4xl mx-auto px-8 py-12">
@@ -134,7 +98,13 @@ export function PageViewer({ page }: PageViewerProps) {
       </div>
 
       {/* Content */}
-      <div className="mb-12">{renderContent(page.content)}</div>
+      <div className="mb-12">
+        {page.content && page.content.content ? (
+          <EditorRenderer content={page.content} />
+        ) : (
+          <p className="text-dim">No content yet. Click Edit to add content.</p>
+        )}
+      </div>
 
       {/* Child Pages */}
       {page.children && page.children.length > 0 && (


### PR DESCRIPTION
…r wiki content sync

This commit fixes the build error and implements the complete solution for provider wiki content display:

1. **Migration Script Fix** (scripts/sync-provider-wiki-to-pages.ts)
   - Fixed TypeScript error by filtering providers in JavaScript instead of using Prisma's JSON field filter
   - Changed from `wikiContent: { not: null }` to `providers.filter(p => p.wikiContent != null)`
   - Proper TypeScript interfaces for WikiContent structure

2. **PageViewer Enhancement** (src/components/workspace/PageViewer.tsx)
   - Replaced simplified renderContent() with EditorRenderer component
   - Now properly handles all TipTap node types (images, links, tables, colors, highlights, etc.)
   - Fixes raw JSON displaying instead of formatted content

3. **Provider Actions Update** (src/provider/actions.ts)
   - Modified updateProvider() to use transaction for atomic updates
   - Automatically syncs wikiContent to Page.content on every update
   - Updates page title and slug when provider metadata changes
   - Ensures workspace pages always display latest wiki content

Fixes #70