### PR TITLE
fix: Add explicit JSONContent type annotation to resolve compilation …

### DIFF
--- a/src/lib/repositories/provider.repository.ts
+++ b/src/lib/repositories/provider.repository.ts
@@ -11,6 +11,7 @@ import { CreateProviderInput, UpdateProviderInput } from '../dtos';
 import { toInputJsonValue } from '../utils/json-helpers';
 import { generateJitteredKeyBetween } from 'fractional-indexing-jittered';
 import { wikiContentToTipTap, tipTapToPlainText } from '../utils/content-transformers';
+import { JSONContent } from '@tiptap/core';
 
 /**
  * Provider with page relation included
@@ -72,7 +73,7 @@ export class ProviderRepository extends BaseRepository<Provider, CreateProviderI
     const title = data.credentials ? `${data.name}, ${data.credentials}` : data.name;
 
     // Prepare page content from WikiContent if provided
-    let pageContent = { type: 'doc', content: [{ type: 'paragraph', content: [] }] };
+    let pageContent: JSONContent = { type: 'doc', content: [{ type: 'paragraph', content: [] }] };
     let textContent = title;
 
     if (data.wikiContent) {


### PR DESCRIPTION
…error

- Import JSONContent type from @tiptap/core
- Add explicit type annotation to pageContent variable in create method
- Resolves type mismatch where inferred type required non-optional 'type' property
- Fixes Next.js build error in provider.repository.ts:79