### PR TITLE
fix: correct provider and search navigation routes

### DIFF
--- a/app/providers/ProvidersPageClient.tsx
+++ b/app/providers/ProvidersPageClient.tsx
@@ -16,7 +16,7 @@ export default function ProvidersPageClient({
   const handleProviderClick = (pageSlug: string | null) => {
     if (pageSlug) {
       // Navigate to the provider's page
-      router.push(`/workspace/pages/${pageSlug}`);
+      router.push(`/home/pages/${pageSlug}`);
     }
   };
 

--- a/src/components/search/SearchModal.tsx
+++ b/src/components/search/SearchModal.tsx
@@ -92,7 +92,7 @@ export default function SearchModal() {
   };
 
   const navigateToResult = (result: SearchResult) => {
-    router.push(`/workspace/pages/${result.slug}`);
+    router.push(`/home/pages/${result.slug}`);
     setIsOpen(false);
     setQuery('');
     setResults([]);


### PR DESCRIPTION
Fixed routing issue where providers tab and search modal were navigating to /workspace/pages/ instead of /home/pages/, causing raw JSON to display instead of formatted wiki pages.

Changes:
- app/providers/ProvidersPageClient.tsx: Updated route to /home/pages/
- src/components/search/SearchModal.tsx: Updated route to /home/pages/

Fixes #77