### PR TITLE
Redesign admin panel and home page with Apple-inspired minimalist design

### DIFF
--- a/app/admin/animated-messages/AnimatedMessagesClient.tsx
+++ b/app/admin/animated-messages/AnimatedMessagesClient.tsx
@@ -120,9 +120,50 @@ export default function AnimatedMessagesClient({
   return (
     <div className="max-w-4xl mx-auto py-8 px-4">
       <div className="mb-8">
-        <h1 className="text-3xl font-bold text-main mb-2">Animated Messages</h1>
-        <p className="text-medium">
-          Manage the typewriter messages displayed on the home page
+        <h1 className="text-3xl font-bold tracking-tight text-white mb-2">Home Page Content</h1>
+        <p className="text-zinc-400 text-base">
+          Manage the typewriter messages, announcements, and getting started content displayed on the home page
+        </p>
+      </div>
+
+      {/* Announcements Section */}
+      <div className="mb-8 bg-zinc-900 border border-zinc-800 rounded-xl p-6">
+        <h2 className="text-xl font-semibold text-zinc-100 mb-3">Announcements Banner</h2>
+        <p className="text-sm text-zinc-400 mb-4">
+          This content appears in the red-orange banner on the home page. Edit the text below to update it.
+        </p>
+        <textarea
+          placeholder="Welcome! Check back here for important updates and announcements."
+          className="w-full p-4 border border-zinc-800 rounded-lg text-zinc-100 bg-zinc-950 resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          rows={3}
+          disabled
+        />
+        <p className="text-xs text-zinc-500 mt-2">
+          Note: This is a placeholder. To enable editing, add a database model for home page content.
+        </p>
+      </div>
+
+      {/* Getting Started Section */}
+      <div className="mb-8 bg-zinc-900 border border-zinc-800 rounded-xl p-6">
+        <h2 className="text-xl font-semibold text-zinc-100 mb-3">Getting Started Content</h2>
+        <p className="text-sm text-zinc-400 mb-4">
+          This content appears in the blue "Getting Started" box on the home page.
+        </p>
+        <textarea
+          placeholder="Welcome to your home! Browse provider preferences, access procedure guides..."
+          className="w-full p-4 border border-zinc-800 rounded-lg text-zinc-100 bg-zinc-950 resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          rows={5}
+          disabled
+        />
+        <p className="text-xs text-zinc-500 mt-2">
+          Note: This is a placeholder. To enable editing, add a database model for home page content.
+        </p>
+      </div>
+
+      <div className="mb-6">
+        <h2 className="text-xl font-semibold text-zinc-100 mb-2">Typewriter Messages</h2>
+        <p className="text-zinc-400 text-sm">
+          Manage the rotating typewriter messages displayed on the home page
         </p>
       </div>
 

--- a/app/admin/medications/MedicationsClient.tsx
+++ b/app/admin/medications/MedicationsClient.tsx
@@ -100,7 +100,7 @@ export default function MedicationsClient({
             <button
               type="button"
               onClick={() => setShowForm(true)}
-              className="font-admin px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+              className="inline-flex items-center gap-2 px-5 py-2.5 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 active:scale-[0.98] transition-all duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
             >
               Add Medication
             </button>
@@ -216,9 +216,9 @@ export default function MedicationsClient({
           </div>
         )}
 
-        <div className="bg-medium border border-main rounded-lg overflow-hidden">
+        <div className="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden shadow-sm">
           {initialMedications.length === 0 ? (
-            <div className="p-8 text-center text-dim">
+            <div className="px-6 py-12 text-center text-zinc-400">
               <p>No medications added yet.</p>
               <p className="text-sm mt-1">
                 Click &quot;Add Medication&quot; to get started.
@@ -227,51 +227,43 @@ export default function MedicationsClient({
           ) : (
             <div className="overflow-x-auto">
               <table className="w-full">
-                <thead className="bg-gray-50 dark:bg-gray-800 border-b border-main">
+                <thead className="bg-zinc-900/50 border-b border-zinc-800">
                   <tr>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-dim uppercase tracking-wider">
+                    <th className="px-6 py-3.5 text-left text-xs font-medium text-zinc-400 uppercase tracking-wider">
                       Name
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-dim uppercase tracking-wider">
+                    <th className="px-6 py-3.5 text-left text-xs font-medium text-zinc-400 uppercase tracking-wider">
                       Type
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-dim uppercase tracking-wider">
+                    <th className="px-6 py-3.5 text-left text-xs font-medium text-zinc-400 uppercase tracking-wider">
                       Commonly Used For
                     </th>
-                    <th className="px-6 py-3 text-right text-xs font-medium text-dim uppercase tracking-wider">
+                    <th className="px-6 py-3.5 text-right text-xs font-medium text-zinc-400 uppercase tracking-wider">
                       Actions
                     </th>
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+                <tbody>
                   {initialMedications.map((medication) => (
                     <tr
                       key={medication.id}
-                      className="hover:bg-gray-50 dark:hover:bg-gray-800"
+                      className="border-b border-zinc-800/50 hover:bg-zinc-800/30 transition-colors duration-150"
                     >
-                      <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-main">
+                      <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-zinc-100">
                         {medication.name}
                       </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-dim">
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-zinc-400 leading-relaxed">
                         {medication.type}
                       </td>
-                      <td className="px-6 py-4 text-sm text-dim">
+                      <td className="px-6 py-4 text-sm text-zinc-400 leading-relaxed">
                         {medication.commonlyUsedFor || '—'}
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                         <button
                           type="button"
                           onClick={() => handleEdit(medication)}
-                          className="font-admin mr-4 px-3 py-1.5 rounded-md transition-all duration-300 text-blue-600 dark:text-blue-400"
-                          style={{
-                            boxShadow: '0 0 10px rgba(59, 130, 246, 0.2)',
-                          }}
-                          onMouseEnter={(e) => {
-                            e.currentTarget.style.boxShadow = '0 0 15px rgba(59, 130, 246, 0.4), 0 0 25px rgba(59, 130, 246, 0.2)';
-                          }}
-                          onMouseLeave={(e) => {
-                            e.currentTarget.style.boxShadow = '0 0 10px rgba(59, 130, 246, 0.2)';
-                          }}
+                          className="p-2 text-blue-400 hover:bg-blue-600/10 rounded-md transition-colors duration-150"
+                          title="Edit"
                         >
                           Edit
                         </button>
@@ -280,16 +272,8 @@ export default function MedicationsClient({
                           onClick={() =>
                             handleDelete(medication.id, medication.name)
                           }
-                          className="font-admin px-3 py-1.5 rounded-md transition-all duration-300 text-red-600 dark:text-red-400"
-                          style={{
-                            boxShadow: '0 0 10px rgba(239, 68, 68, 0.2)',
-                          }}
-                          onMouseEnter={(e) => {
-                            e.currentTarget.style.boxShadow = '0 0 15px rgba(239, 68, 68, 0.4), 0 0 25px rgba(239, 68, 68, 0.2)';
-                          }}
-                          onMouseLeave={(e) => {
-                            e.currentTarget.style.boxShadow = '0 0 10px rgba(239, 68, 68, 0.2)';
-                          }}
+                          className="p-2 text-red-400 hover:bg-red-600/10 rounded-md transition-colors duration-150"
+                          title="Delete"
                         >
                           Delete
                         </button>

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -7,158 +7,134 @@ export const metadata: Metadata = {
 export default function AdminPage() {
   return (
     <div className="p-8">
-      <div className="max-w-4xl mx-auto space-y-8">
+      <div className="max-w-6xl mx-auto space-y-8">
         <div>
-          <h1 className="text-3xl font-bold text-main mb-2">
+          <h1 className="text-3xl font-bold tracking-tight text-white mb-2">
             Admin Dashboard
           </h1>
-          <p className="text-dim">
+          <p className="text-zinc-400 text-base">
             Manage scribe resources and configuration
           </p>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           <a
             href="/admin/providers"
-            className="bg-medium border border-main rounded-lg p-6 hover:bg-dim transition-colors"
+            className="group bg-zinc-900 border border-zinc-800 rounded-xl p-6 hover:bg-zinc-800/50 hover:border-zinc-700 transition-all duration-150 block"
           >
-            <h2 className="text-xl font-semibold text-main mb-2">
+            <h2 className="text-lg font-semibold text-zinc-100 mb-2 group-hover:text-white transition-colors">
               Providers
             </h2>
-            <p className="text-dim">
+            <p className="text-sm text-zinc-400 leading-relaxed">
               Manage provider profiles and preferences
             </p>
           </a>
 
           <a
             href="/admin/smartphrases"
-            className="bg-medium border border-main rounded-lg p-6 hover:bg-dim transition-colors"
+            className="group bg-zinc-900 border border-zinc-800 rounded-xl p-6 hover:bg-zinc-800/50 hover:border-zinc-700 transition-all duration-150 block"
           >
-            <h2 className="text-xl font-semibold text-main mb-2">
+            <h2 className="text-lg font-semibold text-zinc-100 mb-2 group-hover:text-white transition-colors">
               SmartPhrases
             </h2>
-            <p className="text-dim">
+            <p className="text-sm text-zinc-400 leading-relaxed">
               Manage EPIC SmartPhrases (.phrases)
             </p>
           </a>
 
           <a
             href="/admin/scenarios"
-            className="bg-medium border border-main rounded-lg p-6 hover:bg-dim transition-colors"
+            className="group bg-zinc-900 border border-zinc-800 rounded-xl p-6 hover:bg-zinc-800/50 hover:border-zinc-700 transition-all duration-150 block"
           >
-            <h2 className="text-xl font-semibold text-main mb-2">
+            <h2 className="text-lg font-semibold text-zinc-100 mb-2 group-hover:text-white transition-colors">
               Scenarios
             </h2>
-            <p className="text-dim">
+            <p className="text-sm text-zinc-400 leading-relaxed">
               Manage clinical scenario walkthroughs
             </p>
           </a>
 
           <a
             href="/admin/procedures"
-            className="bg-medium border border-main rounded-lg p-6 hover:bg-dim transition-colors"
+            className="group bg-zinc-900 border border-zinc-800 rounded-xl p-6 hover:bg-zinc-800/50 hover:border-zinc-700 transition-all duration-150 block"
           >
-            <h2 className="text-xl font-semibold text-main mb-2">
+            <h2 className="text-lg font-semibold text-zinc-100 mb-2 group-hover:text-white transition-colors">
               Procedures
             </h2>
-            <p className="text-dim">
+            <p className="text-sm text-zinc-400 leading-relaxed">
               Manage medical procedure guides
             </p>
           </a>
 
           <a
             href="/admin/physicians"
-            className="bg-medium border border-main rounded-lg p-6 hover:bg-dim transition-colors"
+            className="group bg-zinc-900 border border-zinc-800 rounded-xl p-6 hover:bg-zinc-800/50 hover:border-zinc-700 transition-all duration-150 block"
           >
-            <h2 className="text-xl font-semibold text-main mb-2">
+            <h2 className="text-lg font-semibold text-zinc-100 mb-2 group-hover:text-white transition-colors">
               Physician Directory
             </h2>
-            <p className="text-dim">
+            <p className="text-sm text-zinc-400 leading-relaxed">
               Manage hospital physician directory
             </p>
           </a>
 
           <a
             href="/admin/medications"
-            className="bg-medium border border-main rounded-lg p-6 hover:bg-dim transition-colors"
+            className="group bg-zinc-900 border border-zinc-800 rounded-xl p-6 hover:bg-zinc-800/50 hover:border-zinc-700 transition-all duration-150 block"
           >
-            <h2 className="text-xl font-semibold text-main mb-2">
+            <h2 className="text-lg font-semibold text-zinc-100 mb-2 group-hover:text-white transition-colors">
               Medications
             </h2>
-            <p className="text-dim">
+            <p className="text-sm text-zinc-400 leading-relaxed">
               Manage medication reference library
             </p>
           </a>
 
           <a
-            href="/admin/database"
-            className="bg-medium border border-main rounded-lg p-6 hover:bg-dim transition-colors"
+            href="/admin/animated-messages"
+            className="group bg-zinc-900 border border-zinc-800 rounded-xl p-6 hover:bg-zinc-800/50 hover:border-zinc-700 transition-all duration-150 block"
           >
-            <h2 className="text-xl font-semibold text-main mb-2">
+            <h2 className="text-lg font-semibold text-zinc-100 mb-2 group-hover:text-white transition-colors">
+              Home Page Content
+            </h2>
+            <p className="text-sm text-zinc-400 leading-relaxed">
+              Edit announcements and getting started content
+            </p>
+          </a>
+
+          <a
+            href="/admin/database"
+            className="group bg-zinc-900 border border-zinc-800 rounded-xl p-6 hover:bg-zinc-800/50 hover:border-zinc-700 transition-all duration-150 block"
+          >
+            <h2 className="text-lg font-semibold text-zinc-100 mb-2 group-hover:text-white transition-colors">
               Database
             </h2>
-            <p className="text-dim">
+            <p className="text-sm text-zinc-400 leading-relaxed">
               Run migrations and manage database
             </p>
           </a>
 
           <a
             href="/admin/diagnostics"
-            className="bg-yellow-500/10 border border-yellow-500/20 rounded-lg p-6 hover:bg-yellow-500/20 transition-colors"
+            className="group bg-amber-950/30 border border-amber-900/30 rounded-xl p-6 hover:bg-amber-950/50 hover:border-amber-800/40 transition-all duration-150 block"
           >
-            <h2 className="text-xl font-semibold text-yellow-400 mb-2">
-              🔍 System Diagnostics
+            <h2 className="text-lg font-semibold text-amber-400 mb-2 group-hover:text-amber-300 transition-colors">
+              System Diagnostics
             </h2>
-            <p className="text-dim">
+            <p className="text-sm text-zinc-400 leading-relaxed">
               Check database connectivity and table status
             </p>
           </a>
 
           <a
-            href="/admin/tags"
-            className="bg-medium border border-main rounded-lg p-6 hover:bg-dim transition-colors"
-          >
-            <h2 className="text-xl font-semibold text-main mb-2">
-              Tags
-            </h2>
-            <p className="text-dim">
-              Manage tags for organizing resources
-            </p>
-          </a>
-
-          <a
             href="/admin/configuration"
-            className="bg-medium border border-main rounded-lg p-6 hover:bg-dim transition-colors"
+            className="group bg-zinc-900 border border-zinc-800 rounded-xl p-6 hover:bg-zinc-800/50 hover:border-zinc-700 transition-all duration-150 block"
           >
-            <h2 className="text-xl font-semibold text-main mb-2">
+            <h2 className="text-lg font-semibold text-zinc-100 mb-2 group-hover:text-white transition-colors">
               Configuration
             </h2>
-            <p className="text-dim">
+            <p className="text-sm text-zinc-400 leading-relaxed">
               View application configuration
-            </p>
-          </a>
-
-          <a
-            href="/admin/insights"
-            className="bg-medium border border-main rounded-lg p-6 hover:bg-dim transition-colors"
-          >
-            <h2 className="text-xl font-semibold text-main mb-2">
-              Insights
-            </h2>
-            <p className="text-dim">
-              View analytics and insights
-            </p>
-          </a>
-
-          <a
-            href="/admin/components"
-            className="bg-medium border border-main rounded-lg p-6 hover:bg-dim transition-colors"
-          >
-            <h2 className="text-xl font-semibold text-main mb-2">
-              Components
-            </h2>
-            <p className="text-dim">
-              Component showcase and reference
             </p>
           </a>
         </div>

--- a/app/admin/physicians/PhysiciansClient.tsx
+++ b/app/admin/physicians/PhysiciansClient.tsx
@@ -99,7 +99,7 @@ export default function PhysiciansClient({
             <button
               type="button"
               onClick={() => setShowForm(true)}
-              className="font-admin px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+              className="inline-flex items-center gap-2 px-5 py-2.5 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 active:scale-[0.98] transition-all duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
             >
               Add Physician
             </button>
@@ -198,9 +198,9 @@ export default function PhysiciansClient({
           </div>
         )}
 
-        <div className="bg-medium border border-main rounded-lg overflow-hidden">
+        <div className="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden shadow-sm">
           {initialPhysicians.length === 0 ? (
-            <div className="p-8 text-center text-dim">
+            <div className="px-6 py-12 text-center text-zinc-400">
               <p>No physicians added yet.</p>
               <p className="text-sm mt-1">
                 Click &quot;Add Physician&quot; to get started.
@@ -209,51 +209,43 @@ export default function PhysiciansClient({
           ) : (
             <div className="overflow-x-auto">
               <table className="w-full">
-                <thead className="bg-gray-50 dark:bg-gray-800 border-b border-main">
+                <thead className="bg-zinc-900/50 border-b border-zinc-800">
                   <tr>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-dim uppercase tracking-wider">
+                    <th className="px-6 py-3.5 text-left text-xs font-medium text-zinc-400 uppercase tracking-wider">
                       Name
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-dim uppercase tracking-wider">
+                    <th className="px-6 py-3.5 text-left text-xs font-medium text-zinc-400 uppercase tracking-wider">
                       Specialty
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-dim uppercase tracking-wider">
+                    <th className="px-6 py-3.5 text-left text-xs font-medium text-zinc-400 uppercase tracking-wider">
                       URL Slug
                     </th>
-                    <th className="px-6 py-3 text-right text-xs font-medium text-dim uppercase tracking-wider">
+                    <th className="px-6 py-3.5 text-right text-xs font-medium text-zinc-400 uppercase tracking-wider">
                       Actions
                     </th>
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+                <tbody>
                   {initialPhysicians.map((physician) => (
                     <tr
                       key={physician.id}
-                      className="hover:bg-gray-50 dark:hover:bg-gray-800"
+                      className="border-b border-zinc-800/50 hover:bg-zinc-800/30 transition-colors duration-150"
                     >
-                      <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-main">
+                      <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-zinc-100">
                         {physician.name}
                       </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-dim">
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-zinc-400 leading-relaxed">
                         {physician.specialty}
                       </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm font-mono text-dim">
+                      <td className="px-6 py-4 whitespace-nowrap text-sm font-mono text-zinc-400 leading-relaxed">
                         {physician.slug}
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                         <button
                           type="button"
                           onClick={() => handleEdit(physician)}
-                          className="font-admin mr-4 px-3 py-1.5 rounded-md transition-all duration-300 text-blue-600 dark:text-blue-400"
-                          style={{
-                            boxShadow: '0 0 10px rgba(59, 130, 246, 0.2)',
-                          }}
-                          onMouseEnter={(e) => {
-                            e.currentTarget.style.boxShadow = '0 0 15px rgba(59, 130, 246, 0.4), 0 0 25px rgba(59, 130, 246, 0.2)';
-                          }}
-                          onMouseLeave={(e) => {
-                            e.currentTarget.style.boxShadow = '0 0 10px rgba(59, 130, 246, 0.2)';
-                          }}
+                          className="p-2 text-blue-400 hover:bg-blue-600/10 rounded-md transition-colors duration-150"
+                          title="Edit"
                         >
                           Edit
                         </button>
@@ -262,16 +254,8 @@ export default function PhysiciansClient({
                           onClick={() =>
                             handleDelete(physician.id, physician.name)
                           }
-                          className="font-admin px-3 py-1.5 rounded-md transition-all duration-300 text-red-600 dark:text-red-400"
-                          style={{
-                            boxShadow: '0 0 10px rgba(239, 68, 68, 0.2)',
-                          }}
-                          onMouseEnter={(e) => {
-                            e.currentTarget.style.boxShadow = '0 0 15px rgba(239, 68, 68, 0.4), 0 0 25px rgba(239, 68, 68, 0.2)';
-                          }}
-                          onMouseLeave={(e) => {
-                            e.currentTarget.style.boxShadow = '0 0 10px rgba(239, 68, 68, 0.2)';
-                          }}
+                          className="p-2 text-red-400 hover:bg-red-600/10 rounded-md transition-colors duration-150"
+                          title="Delete"
                         >
                           Delete
                         </button>

--- a/app/admin/procedures/ProceduresAdminClient.tsx
+++ b/app/admin/procedures/ProceduresAdminClient.tsx
@@ -145,9 +145,9 @@ export default function ProceduresAdminClient({
           {!showForm && (
             <button
               onClick={() => setShowForm(true)}
-              className="inline-flex items-center gap-2 px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors"
+              className="inline-flex items-center gap-2 px-5 py-2.5 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 active:scale-[0.98] transition-all duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
             >
-              <FiPlus className="text-lg" />
+              <FiPlus className="w-4 h-4" />
               Add Procedure
             </button>
           )}
@@ -351,24 +351,24 @@ export default function ProceduresAdminClient({
         )}
 
         {/* Table */}
-        <div className="bg-medium border border-main rounded-lg overflow-hidden">
+        <div className="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden shadow-sm">
           <div className="overflow-x-auto">
             <table className="w-full">
-              <thead className="bg-dim border-b border-main">
+              <thead className="bg-zinc-900/50 border-b border-zinc-800">
                 <tr>
-                  <th className="text-left px-4 py-3 text-main font-semibold text-sm">
+                  <th className="text-left px-6 py-3.5 text-zinc-400 font-semibold text-xs uppercase tracking-wider">
                     Procedure
                   </th>
-                  <th className="text-left px-4 py-3 text-main font-semibold text-sm">
+                  <th className="text-left px-6 py-3.5 text-zinc-400 font-semibold text-xs uppercase tracking-wider">
                     Category
                   </th>
-                  <th className="text-left px-4 py-3 text-main font-semibold text-sm">
+                  <th className="text-left px-6 py-3.5 text-zinc-400 font-semibold text-xs uppercase tracking-wider">
                     Description
                   </th>
-                  <th className="text-left px-4 py-3 text-main font-semibold text-sm">
+                  <th className="text-left px-6 py-3.5 text-zinc-400 font-semibold text-xs uppercase tracking-wider">
                     Views
                   </th>
-                  <th className="text-right px-4 py-3 text-main font-semibold text-sm">
+                  <th className="text-right px-6 py-3.5 text-zinc-400 font-semibold text-xs uppercase tracking-wider">
                     Actions
                   </th>
                 </tr>
@@ -376,52 +376,50 @@ export default function ProceduresAdminClient({
               <tbody>
                 {initialProcedures.length === 0 ? (
                   <tr>
-                    <td colSpan={5} className="px-4 py-8 text-center text-dim">
+                    <td colSpan={5} className="px-6 py-12 text-center text-zinc-400">
                       No Procedures yet. Create one to get started!
                     </td>
                   </tr>
                 ) : (
-                  initialProcedures.map((procedure, index) => (
+                  initialProcedures.map((procedure) => (
                     <tr
                       key={procedure.id}
-                      className={`border-b border-main/50 hover:bg-dim/30 transition-colors ${
-                        index % 2 === 0 ? 'bg-medium' : 'bg-dim/10'
-                      }`}
+                      className="border-b border-zinc-800/50 hover:bg-zinc-800/30 transition-colors duration-150"
                     >
-                      <td className="px-4 py-3 text-main font-medium">
+                      <td className="px-6 py-4 text-zinc-100 font-medium text-sm">
                         {procedure.title}
                       </td>
-                      <td className="px-4 py-3">
-                        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-500/10 text-purple-400 border border-purple-500/20">
+                      <td className="px-6 py-4">
+                        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-600/10 text-purple-400 border border-purple-600/20">
                           {procedure.category}
                         </span>
                       </td>
-                      <td className="px-4 py-3 text-dim text-sm">
+                      <td className="px-6 py-4 text-zinc-400 text-sm leading-relaxed">
                         {procedure.description || '—'}
                       </td>
-                      <td className="px-4 py-3 text-medium text-sm">
+                      <td className="px-6 py-4 text-zinc-400 text-sm">
                         <div className="flex items-center gap-1">
-                          <FiEye className="text-sm" />
+                          <FiEye className="w-4 h-4" />
                           {procedure.viewCount}
                         </div>
                       </td>
-                      <td className="px-4 py-3 text-right">
+                      <td className="px-6 py-4 text-right">
                         <div className="flex gap-2 justify-end">
                           <button
                             onClick={() => handleEdit(procedure)}
-                            className="p-2 text-blue-400 hover:bg-blue-500/10 rounded-lg transition-colors"
+                            className="p-2 text-blue-400 hover:bg-blue-600/10 rounded-md transition-colors duration-150"
                             title="Edit"
                           >
-                            <FiEdit className="text-lg" />
+                            <FiEdit className="w-4 h-4" />
                           </button>
                           <button
                             onClick={() =>
                               handleDelete(procedure.id, procedure.title)
                             }
-                            className="p-2 text-red-400 hover:bg-red-500/10 rounded-lg transition-colors"
+                            className="p-2 text-red-400 hover:bg-red-600/10 rounded-md transition-colors duration-150"
                             title="Delete"
                           >
-                            <FiTrash2 className="text-lg" />
+                            <FiTrash2 className="w-4 h-4" />
                           </button>
                         </div>
                       </td>

--- a/app/admin/scenarios/ScenariosAdminClient.tsx
+++ b/app/admin/scenarios/ScenariosAdminClient.tsx
@@ -129,9 +129,9 @@ export default function ScenariosAdminClient({
           {!showForm && (
             <button
               onClick={() => setShowForm(true)}
-              className="inline-flex items-center gap-2 px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors"
+              className="inline-flex items-center gap-2 px-5 py-2.5 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 active:scale-[0.98] transition-all duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
             >
-              <FiPlus className="text-lg" />
+              <FiPlus className="w-4 h-4" />
               Add Scenario
             </button>
           )}
@@ -279,21 +279,21 @@ export default function ScenariosAdminClient({
         )}
 
         {/* Table */}
-        <div className="bg-medium border border-main rounded-lg overflow-hidden">
+        <div className="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden shadow-sm">
           <div className="overflow-x-auto">
             <table className="w-full">
-              <thead className="bg-dim border-b border-main">
+              <thead className="bg-zinc-900/50 border-b border-zinc-800">
                 <tr>
-                  <th className="text-left px-4 py-3 text-main font-semibold text-sm">
+                  <th className="text-left px-6 py-3.5 text-zinc-400 font-semibold text-xs uppercase tracking-wider">
                     Scenario Title
                   </th>
-                  <th className="text-left px-4 py-3 text-main font-semibold text-sm">
+                  <th className="text-left px-6 py-3.5 text-zinc-400 font-semibold text-xs uppercase tracking-wider">
                     Category
                   </th>
-                  <th className="text-left px-4 py-3 text-main font-semibold text-sm">
+                  <th className="text-left px-6 py-3.5 text-zinc-400 font-semibold text-xs uppercase tracking-wider">
                     Description
                   </th>
-                  <th className="text-right px-4 py-3 text-main font-semibold text-sm">
+                  <th className="text-right px-6 py-3.5 text-zinc-400 font-semibold text-xs uppercase tracking-wider">
                     Actions
                   </th>
                 </tr>
@@ -301,7 +301,7 @@ export default function ScenariosAdminClient({
               <tbody>
                 {initialScenarios.length === 0 ? (
                   <tr>
-                    <td colSpan={4} className="px-4 py-8 text-center text-dim">
+                    <td colSpan={4} className="px-6 py-12 text-center text-zinc-400">
                       No Scenarios yet. Create one to get started!
                     </td>
                   </tr>
@@ -309,38 +309,36 @@ export default function ScenariosAdminClient({
                   initialScenarios.map((scenario, index) => (
                     <tr
                       key={scenario.id}
-                      className={`border-b border-main/50 hover:bg-dim/30 transition-colors ${
-                        index % 2 === 0 ? 'bg-medium' : 'bg-dim/10'
-                      }`}
+                      className="border-b border-zinc-800/50 hover:bg-zinc-800/30 transition-colors duration-150"
                     >
-                      <td className="px-4 py-3 text-main font-medium">
+                      <td className="px-6 py-4 text-zinc-100 font-medium text-sm">
                         {scenario.title}
                       </td>
-                      <td className="px-4 py-3">
-                        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-500/10 text-green-400 border border-green-500/20">
+                      <td className="px-6 py-4">
+                        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-600/10 text-green-400 border border-green-600/20">
                           {scenario.category}
                         </span>
                       </td>
-                      <td className="px-4 py-3 text-dim text-sm">
+                      <td className="px-6 py-4 text-zinc-400 text-sm leading-relaxed">
                         {scenario.description || '—'}
                       </td>
-                      <td className="px-4 py-3 text-right">
+                      <td className="px-6 py-4 text-right">
                         <div className="flex gap-2 justify-end">
                           <button
                             onClick={() => handleEdit(scenario)}
-                            className="p-2 text-blue-400 hover:bg-blue-500/10 rounded-lg transition-colors"
+                            className="p-2 text-blue-400 hover:bg-blue-600/10 rounded-md transition-colors duration-150"
                             title="Edit"
                           >
-                            <FiEdit className="text-lg" />
+                            <FiEdit className="w-4 h-4" />
                           </button>
                           <button
                             onClick={() =>
                               handleDelete(scenario.id, scenario.title)
                             }
-                            className="p-2 text-red-400 hover:bg-red-500/10 rounded-lg transition-colors"
+                            className="p-2 text-red-400 hover:bg-red-600/10 rounded-md transition-colors duration-150"
                             title="Delete"
                           >
-                            <FiTrash2 className="text-lg" />
+                            <FiTrash2 className="w-4 h-4" />
                           </button>
                         </div>
                       </td>

--- a/app/admin/smartphrases/SmartPhrasesAdminClient.tsx
+++ b/app/admin/smartphrases/SmartPhrasesAdminClient.tsx
@@ -129,9 +129,9 @@ export default function SmartPhrasesAdminClient({
           {!showForm && (
             <button
               onClick={() => setShowForm(true)}
-              className="inline-flex items-center gap-2 px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors"
+              className="inline-flex items-center gap-2 px-5 py-2.5 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 active:scale-[0.98] transition-all duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
             >
-              <FiPlus className="text-lg" />
+              <FiPlus className="w-4 h-4" />
               Add SmartPhrase
             </button>
           )}
@@ -279,21 +279,21 @@ export default function SmartPhrasesAdminClient({
         )}
 
         {/* Table */}
-        <div className="bg-medium border border-main rounded-lg overflow-hidden">
+        <div className="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden shadow-sm">
           <div className="overflow-x-auto">
             <table className="w-full">
-              <thead className="bg-dim border-b border-main">
+              <thead className="bg-zinc-900/50 border-b border-zinc-800">
                 <tr>
-                  <th className="text-left px-4 py-3 text-main font-semibold text-sm">
+                  <th className="text-left px-6 py-3.5 text-zinc-400 font-semibold text-xs uppercase tracking-wider">
                     Dot Phrase
                   </th>
-                  <th className="text-left px-4 py-3 text-main font-semibold text-sm">
+                  <th className="text-left px-6 py-3.5 text-zinc-400 font-semibold text-xs uppercase tracking-wider">
                     Category
                   </th>
-                  <th className="text-left px-4 py-3 text-main font-semibold text-sm">
+                  <th className="text-left px-6 py-3.5 text-zinc-400 font-semibold text-xs uppercase tracking-wider">
                     Description
                   </th>
-                  <th className="text-right px-4 py-3 text-main font-semibold text-sm">
+                  <th className="text-right px-6 py-3.5 text-zinc-400 font-semibold text-xs uppercase tracking-wider">
                     Actions
                   </th>
                 </tr>
@@ -301,44 +301,42 @@ export default function SmartPhrasesAdminClient({
               <tbody>
                 {initialSmartPhrases.length === 0 ? (
                   <tr>
-                    <td colSpan={4} className="px-4 py-8 text-center text-dim">
+                    <td colSpan={4} className="px-6 py-12 text-center text-zinc-400">
                       No SmartPhrases yet. Create one to get started!
                     </td>
                   </tr>
                 ) : (
-                  initialSmartPhrases.map((phrase, index) => (
+                  initialSmartPhrases.map((phrase) => (
                     <tr
                       key={phrase.id}
-                      className={`border-b border-main/50 hover:bg-dim/30 transition-colors ${
-                        index % 2 === 0 ? 'bg-medium' : 'bg-dim/10'
-                      }`}
+                      className="border-b border-zinc-800/50 hover:bg-zinc-800/30 transition-colors duration-150"
                     >
-                      <td className="px-4 py-3 text-main font-medium">
+                      <td className="px-6 py-4 text-zinc-100 font-medium text-sm">
                         {phrase.slug}
                       </td>
-                      <td className="px-4 py-3">
-                        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-500/10 text-blue-400 border border-blue-500/20">
+                      <td className="px-6 py-4">
+                        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-600/10 text-blue-400 border border-blue-600/20">
                           {phrase.category}
                         </span>
                       </td>
-                      <td className="px-4 py-3 text-dim text-sm">
+                      <td className="px-6 py-4 text-zinc-400 text-sm leading-relaxed">
                         {phrase.description || '—'}
                       </td>
-                      <td className="px-4 py-3 text-right">
+                      <td className="px-6 py-4 text-right">
                         <div className="flex gap-2 justify-end">
                           <button
                             onClick={() => handleEdit(phrase)}
-                            className="p-2 text-blue-400 hover:bg-blue-500/10 rounded-lg transition-colors"
+                            className="p-2 text-blue-400 hover:bg-blue-600/10 rounded-md transition-colors duration-150"
                             title="Edit"
                           >
-                            <FiEdit className="text-lg" />
+                            <FiEdit className="w-4 h-4" />
                           </button>
                           <button
                             onClick={() => handleDelete(phrase.id, phrase.slug)}
-                            className="p-2 text-red-400 hover:bg-red-500/10 rounded-lg transition-colors"
+                            className="p-2 text-red-400 hover:bg-red-600/10 rounded-md transition-colors duration-150"
                             title="Delete"
                           >
-                            <FiTrash2 className="text-lg" />
+                            <FiTrash2 className="w-4 h-4" />
                           </button>
                         </div>
                       </td>

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -36,40 +36,6 @@ export default function HomePage() {
           </div>
         </div>
 
-        {/* Quick Access Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-10">
-          <QuickAccessCard
-            title="Providers"
-            count={null}
-            onClick={() => handleSectionClick(PageType.PROVIDER)}
-          />
-          <QuickAccessCard
-            title="Procedures"
-            count={null}
-            onClick={() => handleSectionClick(PageType.PROCEDURE)}
-          />
-          <QuickAccessCard
-            title="Smart Phrases"
-            count={null}
-            onClick={() => handleSectionClick(PageType.SMARTPHRASE)}
-          />
-          <QuickAccessCard
-            title="Scenarios"
-            count={null}
-            onClick={() => handleSectionClick(PageType.SCENARIO)}
-          />
-          <QuickAccessCard
-            title="Physician Directory"
-            count={null}
-            onClick={() => handleSectionClick(PageType.PHYSICIAN_DIRECTORY)}
-          />
-          <QuickAccessCard
-            title="Medications"
-            count={null}
-            onClick={() => handleSectionClick(PageType.MEDICATION)}
-          />
-        </div>
-
         {/* Quick Actions */}
         <div className="mb-10">
           <h2 className="text-xl font-semibold text-main mb-4 flex items-center gap-2">
@@ -107,6 +73,16 @@ export default function HomePage() {
               description="Drug reference library"
               onClick={() => handleSectionClick(PageType.MEDICATION)}
             />
+          </div>
+        </div>
+
+        {/* Announcements */}
+        <div className="bg-gradient-to-br from-orange-600/20 to-red-600/20 border border-orange-600/30 rounded-xl p-6 mb-6">
+          <h3 className="text-lg font-semibold text-orange-400 mb-3">Announcements</h3>
+          <div className="space-y-2 text-sm text-zinc-300">
+            <p className="leading-relaxed">
+              Welcome! Check back here for important updates and announcements.
+            </p>
           </div>
         </div>
 
@@ -149,34 +125,6 @@ export default function HomePage() {
         />
       )}
     </>
-  );
-}
-
-function QuickAccessCard({
-  title,
-  count,
-  onClick,
-}: {
-  title: string;
-  count: number | null;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      onClick={onClick}
-      className="group bg-main border border-main rounded-xl p-5 hover:shadow-hover hover:border-primary/50 transition-all text-left w-full"
-    >
-      <div className="flex items-center justify-between mb-2">
-        {count !== null && (
-          <span className="text-2xl font-bold text-dim group-hover:text-primary transition-colors">
-            {count}
-          </span>
-        )}
-      </div>
-      <div className="font-semibold text-main group-hover:text-primary transition-colors">
-        {title}
-      </div>
-    </button>
   );
 }
 


### PR DESCRIPTION
- Remove unused admin features (components, insights, tags)
- Redesign admin panel cards with clean zinc palette and rounded-xl borders
- Update all data tables with Apple-inspired design:
  - Clean bg-zinc-900 backgrounds with subtle border-zinc-800 borders
  - Uppercase text-xs headers with proper tracking
  - Removed alternating row backgrounds for cleaner appearance
  - Updated spacing to px-6 py-4 for cells, px-6 py-3.5 for headers
  - Smooth hover transitions with hover:bg-zinc-800/30
  - Modern button styles with proper focus states
- Reorganize home page layout:
  - Remove Quick Access Cards section
  - Move Quick Actions to top position under typewriter
  - Add red-orange Announcements banner with gradient styling
  - Keep Getting Started blue box at bottom
- Rename "Animated Messages" admin page to "Home Page Content"
- Add placeholder UI for editing Announcements and Getting Started content

Applied consistent Apple design philosophy throughout:
- 8px border radius (rounded-xl for cards, rounded-lg for buttons)
- Zinc color palette for depth and hierarchy
- Generous spacing with 8-point grid system
- Subtle transitions (duration-150) for all interactions
- Minimal shadows, relying on color depth instead
