### PR TITLE
Fix Vercel build error by running migrations in build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "scribe-dashboard",
   "scripts": {
     "dev": "npm run migrate && next dev --turbo",
-    "build": "prisma generate && next build",
+    "build": "npm run migrate && prisma generate && next build",
     "start": "npm run migrate && next start",
     "lint": "next lint",
     "test": "jest --watch --transformIgnorePatterns 'node_modules/(?!my-library-dir)/'",


### PR DESCRIPTION
The Vercel build was failing because the build script didn't run database migrations before generating the Prisma client and building Next.js. This caused a mismatch where the schema expected the Provider.icon column but it didn't exist in the database yet.

Updated the build script to run migrations first, ensuring the database schema is up to date before the build process.

Fixes #83