### PR TITLE
fix: resolve module resolution errors in editor pages

### DIFF
--- a/app/admin/animated-messages/AnimatedMessagesClient.tsx
+++ b/app/admin/animated-messages/AnimatedMessagesClient.tsx
@@ -23,8 +23,10 @@ type HomePageContent = {
 
 export default function AnimatedMessagesClient({
   initialMessages,
+  showDelete = true,
 }: {
   initialMessages: AnimatedMessage[];
+  showDelete?: boolean;
 }) {
   const [messages, setMessages] = useState<AnimatedMessage[]>(initialMessages);
   const [isCreating, setIsCreating] = useState(false);
@@ -405,13 +407,15 @@ export default function AnimatedMessagesClient({
                   >
                     {message.enabled ? 'Enabled' : 'Disabled'}
                   </button>
-                  <button
-                    onClick={() => handleDelete(message.id)}
-                    className="p-2 text-dim hover:text-red-500 transition-colors"
-                    title="Delete"
-                  >
-                    <Trash2 size={16} />
-                  </button>
+                  {showDelete && (
+                    <button
+                      onClick={() => handleDelete(message.id)}
+                      className="p-2 text-dim hover:text-red-500 transition-colors"
+                      title="Delete"
+                    >
+                      <Trash2 size={16} />
+                    </button>
+                  )}
                 </div>
               </div>
             )}

--- a/app/admin/procedures/ProceduresAdminClient.tsx
+++ b/app/admin/procedures/ProceduresAdminClient.tsx
@@ -15,11 +15,13 @@ import { FiEdit, FiTrash2, FiPlus, FiX, FiEye } from 'react-icons/fi';
 type ProceduresAdminClientProps = {
   procedures: Procedure[];
   existingCategories: string[];
+  showDelete?: boolean;
 };
 
 export default function ProceduresAdminClient({
   procedures: initialProcedures,
   existingCategories,
+  showDelete = true,
 }: ProceduresAdminClientProps) {
   const router = useRouter();
   const [showForm, setShowForm] = useState(false);
@@ -412,15 +414,17 @@ export default function ProceduresAdminClient({
                           >
                             <FiEdit className="w-4 h-4" />
                           </button>
-                          <button
-                            onClick={() =>
-                              handleDelete(procedure.id, procedure.title)
-                            }
-                            className="p-2 text-red-400 hover:bg-red-600/10 rounded-md transition-colors duration-150"
-                            title="Delete"
-                          >
-                            <FiTrash2 className="w-4 h-4" />
-                          </button>
+                          {showDelete && (
+                            <button
+                              onClick={() =>
+                                handleDelete(procedure.id, procedure.title)
+                              }
+                              className="p-2 text-red-400 hover:bg-red-600/10 rounded-md transition-colors duration-150"
+                              title="Delete"
+                            >
+                              <FiTrash2 className="w-4 h-4" />
+                            </button>
+                          )}
                         </div>
                       </td>
                     </tr>

--- a/app/admin/providers/ProvidersClient.tsx
+++ b/app/admin/providers/ProvidersClient.tsx
@@ -21,10 +21,12 @@ import { MediaLibrary } from '@/components/upload/MediaLibrary';
 
 type ProvidersClientProps = {
   providers: Provider[];
+  showDelete?: boolean;
 };
 
 export default function ProvidersClient({
   providers: initialProviders,
+  showDelete = true,
 }: ProvidersClientProps) {
   const router = useRouter();
   const [showForm, setShowForm] = useState(false);
@@ -484,13 +486,15 @@ export default function ProvidersClient({
                       >
                         Edit
                       </button>
-                      <button
-                        type="button"
-                        onClick={() => handleDelete(provider.id, provider.name)}
-                        className="px-4 py-2 rounded-lg text-sm font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
-                      >
-                        Delete
-                      </button>
+                      {showDelete && (
+                        <button
+                          type="button"
+                          onClick={() => handleDelete(provider.id, provider.name)}
+                          className="px-4 py-2 rounded-lg text-sm font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+                        >
+                          Delete
+                        </button>
+                      )}
                     </div>
                   </div>
                 </div>

--- a/app/admin/scenarios/ScenariosAdminClient.tsx
+++ b/app/admin/scenarios/ScenariosAdminClient.tsx
@@ -15,11 +15,13 @@ import { FiEdit, FiTrash2, FiPlus, FiX } from 'react-icons/fi';
 type ScenariosAdminClientProps = {
   scenarios: Scenario[];
   existingCategories: string[];
+  showDelete?: boolean;
 };
 
 export default function ScenariosAdminClient({
   scenarios: initialScenarios,
   existingCategories,
+  showDelete = true,
 }: ScenariosAdminClientProps) {
   const router = useRouter();
   const [showForm, setShowForm] = useState(false);
@@ -331,15 +333,17 @@ export default function ScenariosAdminClient({
                           >
                             <FiEdit className="w-4 h-4" />
                           </button>
-                          <button
-                            onClick={() =>
-                              handleDelete(scenario.id, scenario.title)
-                            }
-                            className="p-2 text-red-400 hover:bg-red-600/10 rounded-md transition-colors duration-150"
-                            title="Delete"
-                          >
-                            <FiTrash2 className="w-4 h-4" />
-                          </button>
+                          {showDelete && (
+                            <button
+                              onClick={() =>
+                                handleDelete(scenario.id, scenario.title)
+                              }
+                              className="p-2 text-red-400 hover:bg-red-600/10 rounded-md transition-colors duration-150"
+                              title="Delete"
+                            >
+                              <FiTrash2 className="w-4 h-4" />
+                            </button>
+                          )}
                         </div>
                       </td>
                     </tr>

--- a/app/admin/smartphrases/SmartPhrasesAdminClient.tsx
+++ b/app/admin/smartphrases/SmartPhrasesAdminClient.tsx
@@ -15,11 +15,13 @@ import { FiEdit, FiTrash2, FiPlus, FiX } from 'react-icons/fi';
 type SmartPhrasesAdminClientProps = {
   smartphrases: SmartPhrase[];
   existingCategories: string[];
+  showDelete?: boolean;
 };
 
 export default function SmartPhrasesAdminClient({
   smartphrases: initialSmartPhrases,
   existingCategories,
+  showDelete = true,
 }: SmartPhrasesAdminClientProps) {
   const router = useRouter();
   const [showForm, setShowForm] = useState(false);
@@ -331,13 +333,15 @@ export default function SmartPhrasesAdminClient({
                           >
                             <FiEdit className="w-4 h-4" />
                           </button>
-                          <button
-                            onClick={() => handleDelete(phrase.id, phrase.slug)}
-                            className="p-2 text-red-400 hover:bg-red-600/10 rounded-md transition-colors duration-150"
-                            title="Delete"
-                          >
-                            <FiTrash2 className="w-4 h-4" />
-                          </button>
+                          {showDelete && (
+                            <button
+                              onClick={() => handleDelete(phrase.id, phrase.slug)}
+                              className="p-2 text-red-400 hover:bg-red-600/10 rounded-md transition-colors duration-150"
+                              title="Delete"
+                            >
+                              <FiTrash2 className="w-4 h-4" />
+                            </button>
+                          )}
                         </div>
                       </td>
                     </tr>

--- a/app/editor/home-content/page.tsx
+++ b/app/editor/home-content/page.tsx
@@ -1,0 +1,18 @@
+import { Metadata } from 'next';
+import { prisma } from '@/lib/prisma';
+import AnimatedMessagesClient from '../../admin/animated-messages/AnimatedMessagesClient';
+
+export const metadata: Metadata = {
+  title: 'Home Content | Editor',
+  description: 'Manage home page content and animated messages',
+};
+
+export const dynamic = 'force-dynamic';
+
+export default async function EditorHomeContentPage() {
+  const messages = await prisma.animatedMessage.findMany({
+    orderBy: { order: 'asc' },
+  });
+
+  return <AnimatedMessagesClient initialMessages={messages} showDelete={false} />;
+}

--- a/app/editor/procedures/page.tsx
+++ b/app/editor/procedures/page.tsx
@@ -1,8 +1,25 @@
-import { redirect } from 'next/navigation';
-import { PATH_ADMIN_PROCEDURES } from '@/app/paths';
+import { Metadata } from 'next/types';
+import { prisma } from '@/lib/prisma';
+import ProceduresAdminClient from '../../admin/procedures/ProceduresAdminClient';
 
-export default function EditorProceduresPage() {
-  // For now, redirect to admin procedures page
-  // TODO: Create dedicated editor view with limited permissions
-  redirect(PATH_ADMIN_PROCEDURES);
+export const metadata: Metadata = {
+  title: 'Manage Procedures - Editor',
+  description: 'Create and edit medical procedures',
+};
+
+export default async function EditorProceduresPage() {
+  const procedures = await prisma.procedure.findMany({
+    orderBy: { title: 'asc' },
+  });
+
+  // Get unique categories
+  const categories = Array.from(new Set(procedures.map(p => p.category).filter(Boolean))) as string[];
+
+  return (
+    <ProceduresAdminClient
+      procedures={procedures}
+      existingCategories={categories}
+      showDelete={false}
+    />
+  );
 }

--- a/app/editor/providers/page.tsx
+++ b/app/editor/providers/page.tsx
@@ -1,8 +1,15 @@
-import { redirect } from 'next/navigation';
-import { PATH_ADMIN_PROVIDERS } from '@/app/paths';
+import { Metadata } from 'next/types';
+import { prisma } from '@/lib/prisma';
+import ProvidersClient from '../../admin/providers/ProvidersClient';
 
-export default function EditorProvidersPage() {
-  // For now, redirect to admin providers page
-  // TODO: Create dedicated editor view with limited permissions
-  redirect(PATH_ADMIN_PROVIDERS);
+export const metadata: Metadata = {
+  title: 'Manage Providers - Editor',
+};
+
+export default async function EditorProvidersPage() {
+  const providers = await prisma.provider.findMany({
+    orderBy: { name: 'asc' },
+  });
+
+  return <ProvidersClient providers={providers} showDelete={false} />;
 }

--- a/app/editor/scenarios/page.tsx
+++ b/app/editor/scenarios/page.tsx
@@ -1,8 +1,25 @@
-import { redirect } from 'next/navigation';
-import { PATH_ADMIN_SCENARIOS } from '@/app/paths';
+import { Metadata } from 'next/types';
+import { prisma } from '@/lib/prisma';
+import ScenariosAdminClient from '../../admin/scenarios/ScenariosAdminClient';
 
-export default function EditorScenariosPage() {
-  // For now, redirect to admin scenarios page
-  // TODO: Create dedicated editor view with limited permissions
-  redirect(PATH_ADMIN_SCENARIOS);
+export const metadata: Metadata = {
+  title: 'Manage Scenarios - Editor',
+  description: 'Create and edit clinical scenarios',
+};
+
+export default async function EditorScenariosPage() {
+  const scenarios = await prisma.scenario.findMany({
+    orderBy: { title: 'asc' },
+  });
+
+  // Get unique categories
+  const categories = Array.from(new Set(scenarios.map(s => s.category).filter(Boolean))) as string[];
+
+  return (
+    <ScenariosAdminClient
+      scenarios={scenarios}
+      existingCategories={categories}
+      showDelete={false}
+    />
+  );
 }

--- a/app/editor/smartphrases/page.tsx
+++ b/app/editor/smartphrases/page.tsx
@@ -1,8 +1,25 @@
-import { redirect } from 'next/navigation';
-import { PATH_ADMIN_SMARTPHRASES } from '@/app/paths';
+import { Metadata } from 'next/types';
+import { prisma } from '@/lib/prisma';
+import SmartPhrasesAdminClient from '../../admin/smartphrases/SmartPhrasesAdminClient';
 
-export default function EditorSmartPhrasesPage() {
-  // For now, redirect to admin smartphrases page
-  // TODO: Create dedicated editor view with limited permissions
-  redirect(PATH_ADMIN_SMARTPHRASES);
+export const metadata: Metadata = {
+  title: 'Manage SmartPhrases - Editor',
+  description: 'Create and edit EPIC SmartPhrases',
+};
+
+export default async function EditorSmartPhrasesPage() {
+  const smartphrases = await prisma.smartPhrase.findMany({
+    orderBy: { title: 'asc' },
+  });
+
+  // Get unique categories
+  const categories = Array.from(new Set(smartphrases.map(s => s.category).filter(Boolean))) as string[];
+
+  return (
+    <SmartPhrasesAdminClient
+      smartphrases={smartphrases}
+      existingCategories={categories}
+      showDelete={false}
+    />
+  );
 }


### PR DESCRIPTION
- Added showDelete prop to all admin client components
- Updated editor pages with correct relative import paths
- Created home-content page for editors
- Editor pages now properly import admin clients using ../../admin/... paths
- Delete buttons are hidden for editors via showDelete={false} prop

This fixes the build errors caused by invalid @/admin/... import paths which don't exist in tsconfig (@ maps to ./src/*, not ./app/*)