### PR TITLE
fix: remove gradient backgrounds from redesigned pages

### DIFF
--- a/app/procedures/ProceduresPageClient.tsx
+++ b/app/procedures/ProceduresPageClient.tsx
@@ -86,7 +86,7 @@ export default function ProceduresPageClient({
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-gray-950 dark:via-black dark:to-gray-900">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
       <div className="max-w-7xl mx-auto px-6 py-16">
         {/* Header Section */}
         <div className="mb-12 text-center">

--- a/app/providers/ProvidersPageClient.tsx
+++ b/app/providers/ProvidersPageClient.tsx
@@ -37,7 +37,7 @@ export default function ProvidersPageClient({
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-gray-950 dark:via-black dark:to-gray-900">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
       <div className="max-w-7xl mx-auto px-6 py-16">
         {/* Header Section */}
         <div className="mb-12 text-center">

--- a/app/scenarios/ScenariosPageClient.tsx
+++ b/app/scenarios/ScenariosPageClient.tsx
@@ -81,7 +81,7 @@ export default function ScenariosPageClient({
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-gray-950 dark:via-black dark:to-gray-900">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
       <div className="max-w-7xl mx-auto px-6 py-16">
         {/* Header Section */}
         <div className="mb-12 text-center">

--- a/app/smartphrases/SmartPhrasesPageClient.tsx
+++ b/app/smartphrases/SmartPhrasesPageClient.tsx
@@ -104,7 +104,7 @@ export default function SmartPhrasesPageClient({
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-gray-950 dark:via-black dark:to-gray-900">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
       <div className="max-w-7xl mx-auto px-6 py-16">
         {/* Header Section */}
         <div className="mb-12 text-center">


### PR DESCRIPTION
### Summary

Investigated two visual and performance issues reported in Issue #93.

### Changes

**Issue #2 - Gradient Background Fix ✅**
Removed problematic gradient backgrounds from:
- `app/procedures/ProceduresPageClient.tsx`
- `app/providers/ProvidersPageClient.tsx`
- `app/scenarios/ScenariosPageClient.tsx`
- `app/smartphrases/SmartPhrasesPageClient.tsx`

Replaced `bg-gradient-to-br from-gray-50 via-white to-gray-100` with clean solid backgrounds (`bg-gray-50 dark:bg-gray-950`) that align with Apple's minimalist design philosophy.

**Issue #1 - Provider Page Performance ℹ️**
Investigated the 0.5-1s loading delay on provider detail pages. Analysis shows the page is already optimized with:
- Server-side rendering (SSR)
- React cache() for deduplication
- Async page view tracking

The delay appears to be infrastructural (database latency, serverless cold starts, or TipTap hydration) rather than code-related. No code changes needed.

### Testing

- [ ] Verify gradient backgrounds removed on all 4 pages
- [ ] Confirm pages now have consistent solid backgrounds
- [ ] Check dark mode appearance

Closes #93
