### PR TITLE
fix: remove gradient backgrounds from redesigned pages

### DIFF
--- a/app/procedures/ProceduresPageClient.tsx
+++ b/app/procedures/ProceduresPageClient.tsx
@@ -86,7 +86,7 @@ export default function ProceduresPageClient({
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-gray-950 dark:via-black dark:to-gray-900">
+    <div className="min-h-screen">
       <div className="max-w-7xl mx-auto px-6 py-16">
         {/* Header Section */}
         <div className="mb-12 text-center">

--- a/app/providers/ProvidersPageClient.tsx
+++ b/app/providers/ProvidersPageClient.tsx
@@ -37,7 +37,7 @@ export default function ProvidersPageClient({
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-gray-950 dark:via-black dark:to-gray-900">
+    <div className="min-h-screen">
       <div className="max-w-7xl mx-auto px-6 py-16">
         {/* Header Section */}
         <div className="mb-12 text-center">

--- a/app/scenarios/ScenariosPageClient.tsx
+++ b/app/scenarios/ScenariosPageClient.tsx
@@ -81,7 +81,7 @@ export default function ScenariosPageClient({
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-gray-950 dark:via-black dark:to-gray-900">
+    <div className="min-h-screen">
       <div className="max-w-7xl mx-auto px-6 py-16">
         {/* Header Section */}
         <div className="mb-12 text-center">

--- a/app/smartphrases/SmartPhrasesPageClient.tsx
+++ b/app/smartphrases/SmartPhrasesPageClient.tsx
@@ -104,7 +104,7 @@ export default function SmartPhrasesPageClient({
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-gray-950 dark:via-black dark:to-gray-900">
+    <div className="min-h-screen">
       <div className="max-w-7xl mx-auto px-6 py-16">
         {/* Header Section */}
         <div className="mb-12 text-center">


### PR DESCRIPTION
Remove bg-gradient-to-br backgrounds from procedures, providers, scenarios, and smartphrases pages to match the clean default background used throughout the rest of the website.