### PR TITLE
fix: editor login redirect and apply dark theme to editor panel

### DIFF
--- a/app/editor/EditorNav.tsx
+++ b/app/editor/EditorNav.tsx
@@ -24,12 +24,12 @@ export default function EditorNav() {
   ];
 
   return (
-    <nav className="bg-white shadow-sm">
+    <nav className="border-b border-gray-200 dark:border-gray-800">
       <div className="max-w-7xl mx-auto px-4">
         <div className="flex justify-between items-center h-16">
           <div className="flex space-x-8">
             <div className="flex items-center">
-              <span className="text-xl font-semibold text-gray-900">
+              <span className="text-xl font-semibold">
                 Editor Panel
               </span>
             </div>
@@ -41,8 +41,8 @@ export default function EditorNav() {
                   className={clsx(
                     'inline-flex items-center px-3 py-2 text-sm font-medium rounded-md',
                     pathname === item.href
-                      ? 'bg-blue-100 text-blue-700'
-                      : 'text-gray-700 hover:bg-gray-100'
+                      ? 'font-bold'
+                      : 'text-dim hover:text-main'
                   )}
                 >
                   {item.label}
@@ -52,7 +52,7 @@ export default function EditorNav() {
           </div>
           <button
             onClick={() => signOut()}
-            className="text-sm text-gray-700 hover:text-gray-900"
+            className="text-sm text-dim hover:text-main"
           >
             Sign Out
           </button>

--- a/app/editor/layout.tsx
+++ b/app/editor/layout.tsx
@@ -15,9 +15,9 @@ export default async function EditorLayout({
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen">
       <EditorNav />
-      <main className="max-w-7xl mx-auto px-4 py-8">{children}</main>
+      <main>{children}</main>
     </div>
   );
 }

--- a/app/editor/page.tsx
+++ b/app/editor/page.tsx
@@ -34,27 +34,33 @@ export default async function EditorDashboard() {
   ];
 
   return (
-    <div>
-      <h1 className="text-3xl font-bold text-gray-900 mb-2">
-        Welcome, {session?.user?.name || 'Editor'}
-      </h1>
-      <p className="text-gray-600 mb-8">
-        Manage content across the platform
-      </p>
+    <div className="p-8">
+      <div className="max-w-6xl mx-auto space-y-8">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight text-white mb-2">
+            Welcome, {session?.user?.name || 'Editor'}
+          </h1>
+          <p className="text-zinc-400 text-base">
+            Manage content across the platform
+          </p>
+        </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        {sections.map(section => (
-          <Link
-            key={section.href}
-            href={section.href}
-            className="block p-6 bg-white rounded-lg shadow hover:shadow-md transition-shadow"
-          >
-            <h2 className="text-xl font-semibold text-gray-900 mb-2">
-              {section.title}
-            </h2>
-            <p className="text-gray-600">{section.description}</p>
-          </Link>
-        ))}
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {sections.map(section => (
+            <Link
+              key={section.href}
+              href={section.href}
+              className="group bg-zinc-900 border border-zinc-800 rounded-xl p-6 hover:bg-zinc-800/50 hover:border-zinc-700 transition-all duration-150 block"
+            >
+              <h2 className="text-lg font-semibold text-zinc-100 mb-2 group-hover:text-white transition-colors">
+                {section.title}
+              </h2>
+              <p className="text-sm text-zinc-400 leading-relaxed">
+                {section.description}
+              </p>
+            </Link>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/src/auth/SignInForm.tsx
+++ b/src/auth/SignInForm.tsx
@@ -107,11 +107,11 @@ export default function SignInForm({
               value={password}
               onChange={setPassword}
             />
-            {shouldRedirect &&
+            {shouldRedirect && params.get(KEY_CALLBACK_URL) &&
               <input
                 type="hidden"
                 name={KEY_CALLBACK_URL}
-                value={params.get(KEY_CALLBACK_URL) || PATH_ADMIN_PHOTOS}
+                value={params.get(KEY_CALLBACK_URL) || ''}
               />}
           </div>
           <SubmitButtonWithStatus disabled={!isFormValid}>


### PR DESCRIPTION
- Remove hardcoded PATH_ADMIN_PHOTOS callback in SignInForm
- Allow role-based redirect to work correctly for editors
- Apply admin panel dark theme styling to editor layout
- Update EditorNav with dark theme and consistent styling
- Update editor dashboard with zinc color scheme matching admin
- Remove light backgrounds and apply proper dark mode colors