### PR TITLE
fix: connect terminology page to database and remove placeholder data

### DIFF
--- a/app/terminology/page.tsx
+++ b/app/terminology/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next/types';
 import TerminologyClient from './TerminologyClient';
+import { getTerminologies } from '@/terminology/actions';
 
 export const metadata: Metadata = {
   title: 'Medical Terminology',
@@ -7,5 +8,7 @@ export const metadata: Metadata = {
 };
 
 export default async function TerminologyPage() {
-  return <TerminologyClient />;
+  const terminologies = await getTerminologies();
+
+  return <TerminologyClient terminologies={terminologies} />;
 }


### PR DESCRIPTION
- Update public terminology page to fetch from database via getTerminologies()
- Remove 108 hardcoded placeholder entries from TerminologyClient
- Component now uses database-driven terminology entries
- Maintains fuzzy search and category filtering functionality
- New terminology entries added via admin panel now appear on public page