### PR TITLE
feat: add brand names and fuzzy search to medications

### DIFF
--- a/app/medications/MedicationsClient.tsx
+++ b/app/medications/MedicationsClient.tsx
@@ -1,99 +1,108 @@
 'use client';
 
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo } from 'react';
 import { FiSearch, FiPackage } from 'react-icons/fi';
 import { useDebounce } from 'use-debounce';
 import { Medication } from '@prisma/client';
-import { loadMoreMedications, getMedications, getMedicationsCount } from '@/medication/actions';
 
 type MedicationEntry = {
   name: string;
+  brandNames?: string | null;
   type: string;
-  commonlyUsedFor?: string;
+  commonlyUsedFor?: string | null;
   tags?: string[];
 };
 
 interface MedicationsClientProps {
-  initialMedications: Medication[];
-  totalCount: number;
-  initialLimit: number;
+  allMedications: Medication[];
+}
+
+// Enhanced fuzzy matching with Levenshtein-like scoring
+// This function allows phonetic/misspelled searches (e.g., "Methadoan" finds "Methadone")
+function fuzzyMatch(str: string, pattern: string): number {
+  const strLower = str.toLowerCase();
+  const patternLower = pattern.toLowerCase();
+
+  // Exact match gets highest score
+  if (strLower === patternLower) return 100;
+
+  // Starts with pattern gets very high score
+  if (strLower.startsWith(patternLower)) return 90;
+
+  // Contains pattern gets high score
+  if (strLower.includes(patternLower)) return 80;
+
+  // Fuzzy character-by-character matching for phonetic searches
+  let score = 0;
+  let patternIdx = 0;
+  let consecutiveMatches = 0;
+
+  for (let i = 0; i < strLower.length && patternIdx < patternLower.length; i++) {
+    if (strLower[i] === patternLower[patternIdx]) {
+      score += 2;
+      consecutiveMatches++;
+      // Bonus for consecutive matches (helps with phonetic spelling)
+      if (consecutiveMatches > 1) {
+        score += consecutiveMatches;
+      }
+      patternIdx++;
+    } else {
+      consecutiveMatches = 0;
+    }
+  }
+
+  // All characters found - even if not consecutive
+  if (patternIdx === patternLower.length) {
+    return Math.min((score / strLower.length) * 60, 60);
+  }
+
+  return 0;
 }
 
 export default function MedicationsClient({
-  initialMedications,
-  totalCount: initialTotalCount,
-  initialLimit,
+  allMedications,
 }: MedicationsClientProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const [debouncedQuery] = useDebounce(searchQuery, 300);
-  const [medications, setMedications] = useState<Medication[]>(initialMedications);
-  const [totalCount, setTotalCount] = useState(initialTotalCount);
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
-  const [isSearching, setIsSearching] = useState(false);
-  const [hasMore, setHasMore] = useState(initialMedications.length >= initialLimit);
 
-  // Server-side search effect
-  useEffect(() => {
-    const performSearch = async () => {
-      if (debouncedQuery.trim()) {
-        setIsSearching(true);
-        try {
-          const searchResults = await getMedications({
-            search: debouncedQuery.trim(),
-            limit: initialLimit,
-          });
-          const searchCount = await getMedicationsCount(debouncedQuery.trim());
+  // Filter and rank medications using fuzzy matching
+  const filteredMedications = useMemo(() => {
+    if (!debouncedQuery.trim()) {
+      // Show all medications when no search
+      return allMedications;
+    }
 
-          setMedications(searchResults);
-          setTotalCount(searchCount);
-          setHasMore(searchResults.length < searchCount);
-        } catch (error) {
-          console.error('Search failed:', error);
-        } finally {
-          setIsSearching(false);
-        }
-      } else {
-        // Reset to initial state when search is cleared
-        setMedications(initialMedications);
-        setTotalCount(initialTotalCount);
-        setHasMore(initialMedications.length >= initialLimit);
-      }
-    };
+    const query = debouncedQuery.trim();
 
-    performSearch();
-  }, [debouncedQuery, initialLimit, initialMedications, initialTotalCount]);
+    // Score each medication
+    const scored = allMedications.map(med => {
+      const nameScore = fuzzyMatch(med.name, query);
+      const brandNamesScore = med.brandNames ? fuzzyMatch(med.brandNames, query) * 0.95 : 0; // Brand names almost as important as name
+      const typeScore = fuzzyMatch(med.type, query) * 0.5;
+      const usageScore = med.commonlyUsedFor ? fuzzyMatch(med.commonlyUsedFor, query) * 0.7 : 0;
+
+      return {
+        ...med,
+        score: Math.max(nameScore, brandNamesScore, typeScore, usageScore),
+      };
+    });
+
+    // Filter by score threshold (0 = no match) and sort by score
+    return scored
+      .filter(med => med.score > 0)
+      .sort((a, b) => b.score - a.score);
+  }, [debouncedQuery, allMedications]);
 
   // Convert database medications to display format
   const medicationsList: MedicationEntry[] = useMemo(() => {
-    return medications.map(med => ({
+    return filteredMedications.map(med => ({
       name: med.name,
+      brandNames: med.brandNames,
       type: med.type,
-      commonlyUsedFor: med.commonlyUsedFor || undefined,
+      commonlyUsedFor: med.commonlyUsedFor,
       tags: med.tags,
     }));
-  }, [medications]);
-
-  const handleLoadMore = async () => {
-    if (isLoadingMore || !hasMore) return;
-
-    setIsLoadingMore(true);
-    try {
-      const result = await loadMoreMedications(
-        medications.length,
-        initialLimit,
-        debouncedQuery || undefined
-      );
-
-      setMedications(prev => [...prev, ...result.medications]);
-      setHasMore(result.hasMore);
-    } catch (error) {
-      console.error('Failed to load more medications:', error);
-    } finally {
-      setIsLoadingMore(false);
-    }
-  };
-
-  const showingCount = medicationsList.length;
+  }, [filteredMedications]);
 
   return (
     <div className="min-h-screen">
@@ -109,7 +118,7 @@ export default function MedicationsClient({
             </h1>
           </div>
           <p className="text-lg text-gray-600 dark:text-gray-400 font-light ml-14">
-            Quick reference for all {initialTotalCount.toLocaleString()} medications - search by name, type, or usage
+            Quick reference for all {allMedications.length.toLocaleString()} medications - search by name, brand, type, or usage
           </p>
         </div>
 
@@ -119,20 +128,15 @@ export default function MedicationsClient({
             <FiSearch className="absolute left-5 top-1/2 -translate-y-1/2 text-gray-400 dark:text-gray-500 text-xl pointer-events-none" />
             <input
               type="text"
-              placeholder="Search medications (e.g., 'Methadone', 'beta blocker', 'pain')..."
+              placeholder="Search medications (e.g., 'Methadone', 'Tylenol', 'beta blocker', 'pain')..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               className="w-full bg-white/70 dark:bg-gray-800/70 backdrop-blur-xl border border-gray-200/50 dark:border-gray-700/50 rounded-2xl pl-14 pr-6 py-4 text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500/50 dark:focus:ring-blue-400/50 focus:border-transparent transition-all shadow-sm hover:shadow-md font-light text-base"
             />
           </div>
-          {isSearching && (
+          {debouncedQuery && (
             <p className="text-gray-500 dark:text-gray-400 text-sm mt-3 ml-1 font-light">
-              Searching...
-            </p>
-          )}
-          {debouncedQuery && !isSearching && (
-            <p className="text-gray-500 dark:text-gray-400 text-sm mt-3 ml-1 font-light">
-              Found <span className="font-medium text-gray-700 dark:text-gray-300">{totalCount}</span> result{totalCount !== 1 ? 's' : ''} for &quot;{debouncedQuery}&quot;
+              Found <span className="font-medium text-gray-700 dark:text-gray-300">{medicationsList.length}</span> result{medicationsList.length !== 1 ? 's' : ''} for &quot;{debouncedQuery}&quot;
             </p>
           )}
         </div>
@@ -141,98 +145,89 @@ export default function MedicationsClient({
         {!debouncedQuery && (
           <div className="mb-6">
             <p className="text-gray-500 dark:text-gray-400 text-sm font-light ml-1">
-              Showing {showingCount} of {totalCount} medication{totalCount !== 1 ? 's' : ''}
-              {hasMore && !debouncedQuery && ' (scroll down to load more)'}
+              Showing all {medicationsList.length} medication{medicationsList.length !== 1 ? 's' : ''}
             </p>
           </div>
         )}
 
         {/* Medications List */}
-        {medicationsList.length === 0 && !isSearching ? (
+        {medicationsList.length === 0 ? (
           <div className="bg-white/70 dark:bg-gray-800/70 backdrop-blur-xl border border-gray-200/50 dark:border-gray-700/50 rounded-2xl p-16 text-center shadow-sm">
             <div className="max-w-sm mx-auto">
               <div className="w-16 h-16 bg-gray-100 dark:bg-gray-700 rounded-full flex items-center justify-center mx-auto mb-4">
                 <FiSearch className="text-gray-400 dark:text-gray-500 text-2xl" />
               </div>
               <p className="text-gray-600 dark:text-gray-400 text-lg font-light mb-2">
-                {initialTotalCount === 0 ? 'No medications in database' : 'No medications found'}
+                {allMedications.length === 0 ? 'No medications in database' : 'No medications found'}
               </p>
               <p className="text-gray-400 dark:text-gray-500 text-sm">
-                {initialTotalCount === 0
+                {allMedications.length === 0
                   ? 'Import medications via the admin panel to get started'
                   : 'Try a different search term or check your spelling'}
               </p>
             </div>
           </div>
         ) : (
-          <>
-            <div className="bg-white/70 dark:bg-gray-800/70 backdrop-blur-xl border border-gray-200/50 dark:border-gray-700/50 rounded-2xl overflow-hidden shadow-sm">
-              <div className="divide-y divide-gray-200/50 dark:divide-gray-700/50">
-                {medicationsList.map((med, index) => (
-                  <div
-                    key={index}
-                    className="group px-6 py-5 hover:bg-gray-50/50 dark:hover:bg-gray-900/30 transition-all duration-200"
-                  >
-                    <div className="flex items-start gap-4">
-                      <div className="flex-1 min-w-0">
-                        {/* Medication Name */}
-                        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-1.5 tracking-tight">
-                          {med.name}
-                        </h3>
+          <div className="bg-white/70 dark:bg-gray-800/70 backdrop-blur-xl border border-gray-200/50 dark:border-gray-700/50 rounded-2xl overflow-hidden shadow-sm">
+            <div className="divide-y divide-gray-200/50 dark:divide-gray-700/50">
+              {medicationsList.map((med, index) => (
+                <div
+                  key={index}
+                  className="group px-6 py-5 hover:bg-gray-50/50 dark:hover:bg-gray-900/30 transition-all duration-200"
+                >
+                  <div className="flex items-start gap-4">
+                    <div className="flex-1 min-w-0">
+                      {/* Medication Name */}
+                      <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-1.5 tracking-tight">
+                        {med.name}
+                      </h3>
 
-                        {/* Type Badge */}
-                        <div className="flex items-center gap-2 mb-2">
-                          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-500/10 text-blue-600 dark:text-blue-400 border border-blue-500/20">
-                            {med.type}
-                          </span>
-                        </div>
+                      {/* Brand Names */}
+                      {med.brandNames && (
+                        <p className="text-sm text-blue-600 dark:text-blue-400 font-medium mb-2">
+                          Brand name{med.brandNames.includes(',') ? 's' : ''}: {med.brandNames}
+                        </p>
+                      )}
 
-                        {/* Description */}
-                        {med.commonlyUsedFor && (
-                          <p className="text-sm text-gray-600 dark:text-gray-400 leading-relaxed font-light">
-                            {med.commonlyUsedFor}
-                          </p>
-                        )}
-
-                        {/* Tags */}
-                        {med.tags && med.tags.length > 0 && (
-                          <div className="flex flex-wrap gap-1.5 mt-2">
-                            {med.tags.map((tag, tagIdx) => (
-                              <span
-                                key={tagIdx}
-                                className="inline-flex items-center px-2 py-0.5 rounded-md text-xs bg-gray-500/10 text-gray-600 dark:text-gray-400"
-                              >
-                                {tag}
-                              </span>
-                            ))}
-                          </div>
-                        )}
+                      {/* Type Badge */}
+                      <div className="flex items-center gap-2 mb-2">
+                        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-500/10 text-blue-600 dark:text-blue-400 border border-blue-500/20">
+                          {med.type}
+                        </span>
                       </div>
+
+                      {/* Description */}
+                      {med.commonlyUsedFor && (
+                        <p className="text-sm text-gray-600 dark:text-gray-400 leading-relaxed font-light">
+                          {med.commonlyUsedFor}
+                        </p>
+                      )}
+
+                      {/* Tags */}
+                      {med.tags && med.tags.length > 0 && (
+                        <div className="flex flex-wrap gap-1.5 mt-2">
+                          {med.tags.map((tag, tagIdx) => (
+                            <span
+                              key={tagIdx}
+                              className="inline-flex items-center px-2 py-0.5 rounded-md text-xs bg-gray-500/10 text-gray-600 dark:text-gray-400"
+                            >
+                              {tag}
+                            </span>
+                          ))}
+                        </div>
+                      )}
                     </div>
                   </div>
-                ))}
-              </div>
+                </div>
+              ))}
             </div>
-
-            {/* Load More Button */}
-            {hasMore && !debouncedQuery && (
-              <div className="mt-6 text-center">
-                <button
-                  onClick={handleLoadMore}
-                  disabled={isLoadingMore}
-                  className="px-6 py-3 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 text-white rounded-lg font-medium transition-colors disabled:cursor-not-allowed"
-                >
-                  {isLoadingMore ? 'Loading...' : `Load More (${totalCount - showingCount} remaining)`}
-                </button>
-              </div>
-            )}
-          </>
+          </div>
         )}
 
         {/* Info Note */}
         <div className="mt-8 bg-blue-50/50 dark:bg-blue-900/10 backdrop-blur-xl border border-blue-200/50 dark:border-blue-800/50 rounded-2xl p-5">
           <p className="text-sm text-gray-600 dark:text-gray-400 font-light">
-            <span className="font-medium text-gray-900 dark:text-gray-200">💡 Tip:</span> Search works across all {initialTotalCount.toLocaleString()} medications in the database. Results appear as you type with automatic debouncing.
+            <span className="font-medium text-gray-900 dark:text-gray-200">💡 Tip:</span> Search supports fuzzy matching - you don&apos;t need to spell medications exactly. Try phonetic spelling (e.g., &quot;methadoan&quot; finds &quot;Methadone&quot;). Search works across medication names, brand names, types, and uses.
           </p>
         </div>
       </div>

--- a/app/medications/page.tsx
+++ b/app/medications/page.tsx
@@ -1,24 +1,19 @@
 import { Metadata } from 'next/types';
 import MedicationsClient from './MedicationsClient';
-import { getMedications, getMedicationsCount } from '@/medication/actions';
+import { getAllMedications } from '@/medication/actions';
 
 export const metadata: Metadata = {
   title: 'Medications',
   description: 'Medication reference and lookup tool',
 };
 
-const INITIAL_LIMIT = 50;
-
 export default async function MedicationsPage() {
-  // Load initial batch of medications
-  const medications = await getMedications({ limit: INITIAL_LIMIT });
-  const totalCount = await getMedicationsCount();
+  // Load all medications for client-side fuzzy search
+  const medications = await getAllMedications();
 
   return (
     <MedicationsClient
-      initialMedications={medications}
-      totalCount={totalCount}
-      initialLimit={INITIAL_LIMIT}
+      allMedications={medications}
     />
   );
 }

--- a/prisma/migrations/20251125000000_add_brand_names_to_medications/migration.sql
+++ b/prisma/migrations/20251125000000_add_brand_names_to_medications/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Medication" ADD COLUMN "brandNames" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -212,6 +212,7 @@ model Medication {
   id              String   @id @default(cuid())
   slug            String   @unique
   name            String
+  brandNames      String?  // Brand names (e.g., "Tylenol", "ProAir, Ventolin")
   type            String   // e.g., "Antibiotic", "Analgesic"
   commonlyUsedFor String?  // Description
   tags            String[] // For fuzzy search

--- a/scripts/seed-medications.js
+++ b/scripts/seed-medications.js
@@ -102,13 +102,13 @@ async function seedMedications() {
       }
       parts.push(current.trim()); // Add last field
 
-      if (parts.length < 2) {
+      if (parts.length < 3) {
         failCount++;
-        errors.push(`Line ${i + 1}: Invalid format (needs at least Name and Type)`);
+        errors.push(`Line ${i + 1}: Invalid format (needs at least Name, Brand Names, and Type)`);
         continue;
       }
 
-      const [name, type, commonlyUsedFor] = parts;
+      const [name, brandNames, type, commonlyUsedFor] = parts;
 
       // Generate slug from name
       const slug = name
@@ -134,12 +134,13 @@ async function seedMedications() {
         // Insert medication
         await client.query(
           `INSERT INTO "Medication" (
-            id, slug, name, type, "commonlyUsedFor", tags, "viewCount", "createdAt", "updatedAt"
-          ) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW())`,
+            id, slug, name, "brandNames", type, "commonlyUsedFor", tags, "viewCount", "createdAt", "updatedAt"
+          ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW(), NOW())`,
           [
             id,
             slug,
             name,
+            brandNames && brandNames.trim() ? brandNames.trim() : null,
             type || 'Unknown',
             commonlyUsedFor || null,
             [], // tags


### PR DESCRIPTION
- Add brandNames field to Medication schema
- Update seed script to import brand names from CSV (column 2)
- Implement client-side fuzzy matching for phonetic searches
- Display brand names prominently in medication list
- Search across medication name, brand names, type, and usage
- Load all medications for instant fuzzy search (no pagination)
- Fuzzy matching supports phonetic spelling (e.g., "methadoan" → "Methadone")

Fixes #112