### PR TITLE
fix: add missing brandNames migration to run-migrations script

### DIFF
--- a/scripts/run-migrations.js
+++ b/scripts/run-migrations.js
@@ -615,6 +615,21 @@ BEGIN
 END $$;
     `,
   },
+  {
+    name: '20251125000000_add_brand_names_to_medications',
+    sql: `
+-- Add brandNames column to Medication table (only if not exists)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'Medication' AND column_name = 'brandNames'
+    ) THEN
+        ALTER TABLE "Medication" ADD COLUMN "brandNames" TEXT;
+    END IF;
+END $$;
+    `,
+  },
 ];
 
 async function runMigrations() {


### PR DESCRIPTION
The brandNames column migration was created but never added to the run-migrations.js MIGRATIONS array. This caused the database to be missing the brandNames column, which made the seed script fail silently, resulting in an empty medications list.

This commit adds the missing migration to ensure the brandNames column is created before seeding medications.