### PR TITLE
fix: handle JsonValue type for scenario content in migration script

### DIFF
--- a/app/api/migrate-pages/route.ts
+++ b/app/api/migrate-pages/route.ts
@@ -212,22 +212,34 @@ export async function GET() {
       let position = generateJitteredKeyBetween(null, null);
 
       for (const scenario of scenarios) {
-        const content = {
-          type: 'doc',
-          content: [
-            {
-              type: 'paragraph',
-              content: [{ type: 'text', text: scenario.content }],
-            },
-          ],
-        };
+        let content;
+        let textContent;
+
+        // Handle both legacy string content and new JSON content
+        if (typeof scenario.content === 'string') {
+          // Legacy format: plain text string
+          content = {
+            type: 'doc',
+            content: [
+              {
+                type: 'paragraph',
+                content: [{ type: 'text', text: scenario.content }],
+              },
+            ],
+          };
+          textContent = scenario.content;
+        } else {
+          // New format: TipTap JSON
+          content = scenario.content;
+          textContent = tipTapToPlainText(scenario.content);
+        }
 
         await prisma.page.create({
           data: {
             slug: scenario.slug,
             title: scenario.title,
             content,
-            textContent: scenario.content,
+            textContent: textContent || scenario.title,
             type: PageType.SCENARIO,
             position,
             icon: '🚨',


### PR DESCRIPTION
The rich text editor PR changed scenario.content from String to Json. Updated the migrate-pages route to:
- Check if content is JSON (new format) or string (legacy)
- Use JSON content directly when available
- Extract plain text using tipTapToPlainText() for textContent field
- Handle both formats for backward compatibility

Fixes TypeScript compilation error at line 230.