### PR TITLE
fix: serialize Date objects when passing Prisma data to client compon…

### DIFF
--- a/app/admin/providers/page.tsx
+++ b/app/admin/providers/page.tsx
@@ -7,9 +7,16 @@ export const metadata: Metadata = {
 };
 
 export default async function ProvidersPage() {
-  const providers = await prisma.provider.findMany({
+  const providersRaw = await prisma.provider.findMany({
     orderBy: { name: 'asc' },
   });
 
-  return <ProvidersClient providers={providers} />;
+  // Serialize data for client component (convert Dates to strings)
+  const providers = providersRaw.map(provider => ({
+    ...provider,
+    createdAt: provider.createdAt.toISOString(),
+    updatedAt: provider.updatedAt.toISOString(),
+  }));
+
+  return <ProvidersClient providers={providers as any} />;
 }

--- a/app/admin/scenarios/page.tsx
+++ b/app/admin/scenarios/page.tsx
@@ -8,16 +8,23 @@ export const metadata: Metadata = {
 };
 
 export default async function ScenariosAdminPage() {
-  const scenarios = await prisma.scenario.findMany({
+  const scenariosRaw = await prisma.scenario.findMany({
     orderBy: { title: 'asc' },
   });
+
+  // Serialize data for client component (convert Dates to strings)
+  const scenarios = scenariosRaw.map(scenario => ({
+    ...scenario,
+    createdAt: scenario.createdAt.toISOString(),
+    updatedAt: scenario.updatedAt.toISOString(),
+  }));
 
   // Get unique categories
   const categories = Array.from(new Set(scenarios.map(s => s.category).filter(Boolean))) as string[];
 
   return (
     <ScenariosAdminClient
-      scenarios={scenarios}
+      scenarios={scenarios as any}
       existingCategories={categories}
     />
   );

--- a/app/editor/providers/page.tsx
+++ b/app/editor/providers/page.tsx
@@ -7,9 +7,16 @@ export const metadata: Metadata = {
 };
 
 export default async function EditorProvidersPage() {
-  const providers = await prisma.provider.findMany({
+  const providersRaw = await prisma.provider.findMany({
     orderBy: { name: 'asc' },
   });
 
-  return <ProvidersClient providers={providers} showDelete={false} />;
+  // Serialize data for client component (convert Dates to strings)
+  const providers = providersRaw.map(provider => ({
+    ...provider,
+    createdAt: provider.createdAt.toISOString(),
+    updatedAt: provider.updatedAt.toISOString(),
+  }));
+
+  return <ProvidersClient providers={providers as any} showDelete={false} />;
 }

--- a/app/editor/scenarios/page.tsx
+++ b/app/editor/scenarios/page.tsx
@@ -8,16 +8,23 @@ export const metadata: Metadata = {
 };
 
 export default async function EditorScenariosPage() {
-  const scenarios = await prisma.scenario.findMany({
+  const scenariosRaw = await prisma.scenario.findMany({
     orderBy: { title: 'asc' },
   });
+
+  // Serialize data for client component (convert Dates to strings)
+  const scenarios = scenariosRaw.map(scenario => ({
+    ...scenario,
+    createdAt: scenario.createdAt.toISOString(),
+    updatedAt: scenario.updatedAt.toISOString(),
+  }));
 
   // Get unique categories
   const categories = Array.from(new Set(scenarios.map(s => s.category).filter(Boolean))) as string[];
 
   return (
     <ScenariosAdminClient
-      scenarios={scenarios}
+      scenarios={scenarios as any}
       existingCategories={categories}
       showDelete={false}
     />

--- a/app/providers/page.tsx
+++ b/app/providers/page.tsx
@@ -10,9 +10,9 @@ export const metadata: Metadata = {
 
 export default async function ProvidersPage() {
   // Fetch providers with their associated pages (if table exists)
-  let providers;
+  let providersRaw;
   try {
-    providers = await prisma.provider.findMany({
+    providersRaw = await prisma.provider.findMany({
       orderBy: { name: 'asc' },
       include: {
         page: {
@@ -24,10 +24,17 @@ export default async function ProvidersPage() {
     });
   } catch (error) {
     // Fallback if Page table doesn't exist yet
-    providers = await prisma.provider.findMany({
+    providersRaw = await prisma.provider.findMany({
       orderBy: { name: 'asc' },
     });
   }
+
+  // Serialize data for client component (convert Dates to strings)
+  const providers = providersRaw.map(provider => ({
+    ...provider,
+    createdAt: provider.createdAt.toISOString(),
+    updatedAt: provider.updatedAt.toISOString(),
+  }));
 
   return <ProvidersPageClient providers={providers as any} />;
 }

--- a/app/scenarios/page.tsx
+++ b/app/scenarios/page.tsx
@@ -10,9 +10,9 @@ export const metadata: Metadata = {
 
 export default async function ScenariosPage() {
   // Fetch scenarios with their associated pages (if table exists)
-  let scenarios;
+  let scenariosRaw;
   try {
-    scenarios = await prisma.scenario.findMany({
+    scenariosRaw = await prisma.scenario.findMany({
       orderBy: { title: 'asc' },
       include: {
         page: {
@@ -24,10 +24,17 @@ export default async function ScenariosPage() {
     });
   } catch (error) {
     // Fallback if Page table doesn't exist yet
-    scenarios = await prisma.scenario.findMany({
+    scenariosRaw = await prisma.scenario.findMany({
       orderBy: { title: 'asc' },
     });
   }
+
+  // Serialize data for client component (convert Dates to strings)
+  const scenarios = scenariosRaw.map(scenario => ({
+    ...scenario,
+    createdAt: scenario.createdAt.toISOString(),
+    updatedAt: scenario.updatedAt.toISOString(),
+  }));
 
   // Get unique categories
   const categories = Array.from(new Set(scenarios.map(s => s.category).filter(Boolean))) as string[];


### PR DESCRIPTION
…ents

Fixed 500 errors occurring when accessing providers/scenarios in admin and editor panels. The issue was caused by Prisma returning Date objects (createdAt, updatedAt) which cannot be serialized across Next.js server/client component boundaries.

Changes:
- Converted Date objects to ISO strings before passing to client components
- Applied fix to all 6 affected pages (admin, editor, and public routes)
- Maintains data integrity while ensuring proper serialization

Resolves #125