### PR TITLE
fix: add missing timestamp and content fields to Prisma select clauses

### DIFF
--- a/app/workspace/pages/[slug]/page.tsx
+++ b/app/workspace/pages/[slug]/page.tsx
@@ -27,11 +27,30 @@ export default async function PageViewPage({ params }: PageProps) {
     where: { slug, deletedAt: null },
     include: {
       parent: {
-        select: { id: true, title: true, slug: true, icon: true },
+        select: {
+          id: true,
+          title: true,
+          slug: true,
+          icon: true,
+          createdAt: true,
+          updatedAt: true,
+          deletedAt: true,
+          content: true,
+        },
       },
       children: {
         where: { deletedAt: null },
-        select: { id: true, title: true, slug: true, icon: true, type: true },
+        select: {
+          id: true,
+          title: true,
+          slug: true,
+          icon: true,
+          type: true,
+          createdAt: true,
+          updatedAt: true,
+          deletedAt: true,
+          content: true,
+        },
         orderBy: { position: 'asc' },
       },
     },


### PR DESCRIPTION
Added createdAt, updatedAt, deletedAt, and content fields to parent and children select clauses in workspace pages route. This resolves TypeScript compilation error where serialization code tried to access fields that weren't included in the Prisma query.