### PR TITLE
fix: force dynamic rendering for admin pages to prevent build-time da…

### DIFF
--- a/app/admin/procedures/page.tsx
+++ b/app/admin/procedures/page.tsx
@@ -7,6 +7,9 @@ export const metadata: Metadata = {
   description: 'Create, edit, and delete medical procedures',
 };
 
+// Force dynamic rendering to prevent build-time database access
+export const dynamic = 'force-dynamic';
+
 export default async function ProceduresAdminPage() {
   const proceduresRaw = await prisma.procedure.findMany({
     orderBy: { title: 'asc' },

--- a/app/admin/scenarios/page.tsx
+++ b/app/admin/scenarios/page.tsx
@@ -7,6 +7,9 @@ export const metadata: Metadata = {
   description: 'Create, edit, and delete clinical scenarios',
 };
 
+// Force dynamic rendering to prevent build-time database access
+export const dynamic = 'force-dynamic';
+
 export default async function ScenariosAdminPage() {
   const scenariosRaw = await prisma.scenario.findMany({
     orderBy: { title: 'asc' },


### PR DESCRIPTION
…tabase access

Adds 'export const dynamic = force-dynamic' to /admin/procedures and /admin/scenarios pages to prevent Next.js from attempting to statically generate these pages at build time. This resolves the Prisma database connection error during deployment, as the database is not accessible during the build phase.