### PR TITLE
Refine UI: move header right, compact announcements, redesign buttons

### DIFF
--- a/app/home/HomePageClient.tsx
+++ b/app/home/HomePageClient.tsx
@@ -44,14 +44,14 @@ export default function HomePageClient({ initialContent }: HomePageClientProps) 
         </div>
 
         {/* Announcements - Moved above Quick Actions */}
-        <div className="mb-8 bg-gradient-to-r from-blue-500/10 to-purple-500/10 dark:from-blue-500/5 dark:to-purple-500/5 border border-blue-500/20 rounded-2xl p-6">
-          <div className="flex items-start gap-3">
+        <div className="mb-8 bg-gradient-to-r from-blue-500/10 to-purple-500/10 dark:from-blue-500/5 dark:to-purple-500/5 border border-blue-500/20 rounded-xl p-4">
+          <div className="flex items-start gap-2">
             <div className="flex-shrink-0 w-1 h-full bg-gradient-to-b from-blue-500 to-purple-500 rounded-full"></div>
             <div className="flex-1">
-              <h3 className="text-sm font-semibold text-blue-600 dark:text-blue-400 mb-2 uppercase tracking-wide">
+              <h3 className="text-xs font-semibold text-blue-600 dark:text-blue-400 mb-1.5 uppercase tracking-wide">
                 Announcements
               </h3>
-              <p className="text-base text-main leading-relaxed whitespace-pre-line">
+              <p className="text-sm text-main leading-snug whitespace-pre-line">
                 {initialContent.announcementText}
               </p>
             </div>
@@ -142,14 +142,19 @@ function ActionButton({
   return (
     <button
       onClick={onClick}
-      className="block bg-main border border-main rounded-lg p-4 hover:shadow-soft hover:border-primary/50 transition-all group text-left w-full"
+      className="relative bg-white/50 dark:bg-zinc-800/50 backdrop-blur-sm border border-zinc-200/50 dark:border-zinc-700/50 rounded-xl px-4 py-3 hover:bg-white dark:hover:bg-zinc-800 hover:border-blue-500/30 hover:shadow-[0_2px_8px_rgba(59,130,246,0.1)] dark:hover:shadow-[0_2px_8px_rgba(59,130,246,0.2)] transition-all duration-200 group text-left w-full active:scale-[0.98]"
     >
-      <div className="flex items-start gap-3">
+      <div className="flex items-center justify-between gap-3">
         <div className="flex-1 min-w-0">
-          <div className="font-semibold text-main text-sm mb-0.5 group-hover:text-primary transition-colors">
+          <div className="font-medium text-zinc-900 dark:text-zinc-100 text-sm mb-0.5 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
             {title}
           </div>
-          <div className="text-xs text-dim">{description}</div>
+          <div className="text-xs text-zinc-500 dark:text-zinc-400">{description}</div>
+        </div>
+        <div className="text-zinc-400 dark:text-zinc-500 group-hover:text-blue-500 dark:group-hover:text-blue-400 transition-colors">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M6 12L10 8L6 4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
         </div>
       </div>
     </button>

--- a/src/app/Nav.tsx
+++ b/src/app/Nav.tsx
@@ -79,7 +79,7 @@ export default function Nav({
                 'grow text-right min-w-0',
                 'hidden xs:block',
                 'translate-y-[-1px]',
-                'pr-8',
+                'pr-16',
               )}>
                 <div className="truncate overflow-hidden select-none font-mono">
                   {renderLink(navTitleOrDomain, PATH_ROOT)}


### PR DESCRIPTION
- Increase header URL right padding from pr-8 to pr-16 for significant rightward positioning
- Reduce announcements box size: smaller padding, tighter spacing, reduced font sizes
- Redesign Quick Action buttons with minimalist aesthetic:
  - Frosted glass effect with backdrop blur
  - Compact py-3 padding for shorter horizontal size
  - Refined zinc color scheme with blue accents
  - Active press animation and smooth transitions
  - Enhanced dark mode support