### PR TITLE
Remove getting started section and clean up calendar UI

### DIFF
--- a/app/home/HomePageClient.tsx
+++ b/app/home/HomePageClient.tsx
@@ -106,13 +106,6 @@ export default function HomePageClient({ initialContent }: HomePageClientProps) 
           </div>
         </div>
 
-        {/* Getting Started */}
-        <div className="bg-blue-50 dark:bg-blue-900/10 border border-blue-200 dark:border-blue-800 rounded-xl p-6">
-          <h3 className="text-lg font-semibold text-main mb-3">Getting Started</h3>
-          <div className="space-y-2 text-sm text-medium whitespace-pre-line">
-            {initialContent.gettingStartedText}
-          </div>
-        </div>
       </div>
 
       {/* Section Search Modal */}

--- a/src/components/calendar/ScheduleCalendar.tsx
+++ b/src/components/calendar/ScheduleCalendar.tsx
@@ -111,12 +111,9 @@ function ScheduleCalendar() {
               <div className="inline-flex items-center justify-center w-12 h-12 bg-zinc-100 dark:bg-zinc-800 rounded-full mb-3">
                 <Lock className="w-6 h-6 text-zinc-600 dark:text-zinc-400" />
               </div>
-              <h3 className="text-base font-semibold text-zinc-900 dark:text-zinc-100 mb-1">
+              <h3 className="text-base font-semibold text-zinc-900 dark:text-zinc-100">
                 Scribe/Provider Calendar
               </h3>
-              <p className="text-xs text-zinc-600 dark:text-zinc-400">
-                Protected content
-              </p>
             </div>
 
             <div className="space-y-3">
@@ -128,7 +125,7 @@ function ScheduleCalendar() {
                   placeholder="••••"
                   maxLength={4}
                   className={`
-                    w-full px-4 py-2 text-center text-xl tracking-widest font-medium
+                    w-32 mx-auto block px-4 py-2 text-center text-xl tracking-widest font-medium
                     bg-zinc-100 dark:bg-zinc-800 border-2 rounded-lg
                     text-zinc-900 dark:text-zinc-100
                     placeholder:text-zinc-400 dark:placeholder:text-zinc-600


### PR DESCRIPTION
- Remove "Getting Started" section from bottom of home page
- Remove "Protected content" subheading from calendar
- Make passcode input field shorter and centered (w-32 instead of w-full)