### PR TITLE
feat: Add ShiftGen database with automatic migrations for Vercel

### DIFF
--- a/docs/SHIFTGEN_PHASE1.md
+++ b/docs/SHIFTGEN_PHASE1.md
@@ -1,0 +1,353 @@
+# ShiftGen Integration - Phase 1: Database Schema
+
+## Overview
+
+Phase 1 establishes the database foundation for integrating ShiftGen shift scheduling into the Scribe Dashboard website. This phase focuses on:
+- Creating database tables for shifts and scribes
+- Setting up automatic migrations
+- Configuring Vercel Postgres integration
+- Preparing for API development in Phase 2
+
+## What Was Completed
+
+### 1. Database Schema
+
+Two new Prisma models were added to `prisma/schema.prisma`:
+
+#### **Scribe Model**
+```prisma
+model Scribe {
+  id               String   @id @default(cuid())
+  name             String   @unique
+  standardizedName String?  // Standardized name from name mapper
+
+  shifts           Shift[]  @relation("ScribeShifts")
+
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  @@index([name])
+}
+```
+
+**Purpose:** Store scribe information and link to their shifts.
+
+**Features:**
+- Unique names (prevents duplicates)
+- Name standardization support (for fuzzy matching)
+- One-to-many relationship with shifts
+
+#### **Shift Model**
+```prisma
+model Shift {
+  id        String   @id @default(cuid())
+  date      DateTime @db.Date
+  zone      String   // Zone identifier (A, B, C, PA, etc.)
+  startTime String   // e.g., "0800"
+  endTime   String   // e.g., "1600"
+  site      String   // Site name
+
+  scribeId     String?
+  scribe       Scribe?   @relation("ScribeShifts", fields: [scribeId], references: [id])
+  providerId   String?
+  provider     Provider? @relation("ProviderShifts", fields: [providerId], references: [id])
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([date, zone, startTime, scribeId, providerId])
+  @@index([date])
+  @@index([scribeId, date])
+  @@index([providerId, date])
+}
+```
+
+**Purpose:** Store shift schedules with scribe-provider pairings.
+
+**Features:**
+- Date stored as PostgreSQL `DATE` type (no timezone issues)
+- Zone identifier (A, B, C, PA, etc.) for location/assignment
+- Start/end times as strings (e.g., "0800", "1600")
+- Relations to both Scribe and Provider
+- Unique constraint prevents duplicate shifts
+- Optimized indexes for date-based queries
+
+#### **Provider Model Extension**
+
+Extended the existing `Provider` model:
+```prisma
+model Provider {
+  // ... existing fields ...
+
+  shifts  Shift[]  @relation("ProviderShifts")
+}
+```
+
+### 2. Automatic Migration System
+
+Added migration `20251129000000_add_shift_and_scribe_tables` to `scripts/run-migrations.js`:
+
+**Migration Features:**
+- ✅ **Idempotent:** Safe to run multiple times
+- ✅ **Automatic:** Runs on every build/startup
+- ✅ **No manual commands:** Works with Vercel web interface
+- ✅ **Creates tables** if they don't exist
+- ✅ **Creates indexes** for performance
+- ✅ **Creates foreign keys** for data integrity
+
+**How It Works:**
+
+The migration system is already integrated into your build process:
+
+```json
+{
+  "scripts": {
+    "build": "npm run migrate && prisma generate && next build",
+    "start": "npm run migrate && next start",
+    "dev": "npm run migrate && next dev --turbo"
+  }
+}
+```
+
+Every deployment or local startup:
+1. Runs `npm run migrate` (executes `scripts/run-migrations.js`)
+2. Connects to database
+3. Runs all migrations in order
+4. Skips already-applied migrations
+5. Generates Prisma Client
+6. Starts application
+
+### 3. Database Setup Documentation
+
+Created comprehensive guide at `docs/VERCEL_DATABASE_SETUP.md`:
+
+**Topics Covered:**
+- Setting up Vercel Postgres
+- Environment variable configuration
+- Local development options
+- Database management tools
+- Migration monitoring
+- Troubleshooting
+- Security best practices
+
+**Key Takeaway:** No manual `npx` commands needed! Everything runs automatically.
+
+## Database Schema Diagram
+
+```
+┌─────────────┐         ┌─────────────┐
+│   Scribe    │         │  Provider   │
+├─────────────┤         ├─────────────┤
+│ id          │         │ id          │
+│ name*       │         │ name        │
+│ standardized│         │ slug        │
+└──────┬──────┘         └──────┬──────┘
+       │                       │
+       │    ┌─────────────┐    │
+       └────│    Shift    │────┘
+            ├─────────────┤
+            │ id          │
+            │ date        │ (DATE)
+            │ zone        │ (A, B, C, PA)
+            │ startTime   │ (0800)
+            │ endTime     │ (1600)
+            │ site        │
+            │ scribeId    │ (FK → Scribe)
+            │ providerId  │ (FK → Provider)
+            └─────────────┘
+
+* Unique constraint
+```
+
+## Design Decisions
+
+### 1. Separate Database (Not Railway Bridge)
+
+**Decision:** Use Vercel Postgres instead of bridging to Railway Discord bot database
+
+**Rationale:**
+- Simpler deployment (everything in Vercel)
+- Better performance (same region as app)
+- Easier to manage (one platform)
+- Can sync data from Discord bot via API
+
+**Implementation:**
+- Website has its own Vercel Postgres database
+- Discord bot continues using Railway PostgreSQL
+- Python scraper POSTs data to website API (Phase 2)
+- Both databases stay in sync via scheduled refresh
+
+### 2. Automatic Migrations (No npx Commands)
+
+**Decision:** Use custom SQL migration system instead of Prisma Migrate
+
+**Rationale:**
+- Works with Vercel web interface (no CLI access needed)
+- Idempotent (safe to run repeatedly)
+- Runs automatically on every deployment
+- Handles complex migrations gracefully
+- Already proven to work in your project
+
+**Implementation:**
+- All migrations in `scripts/run-migrations.js`
+- SQL uses `IF NOT EXISTS` checks
+- Runs via `npm run migrate` on every build/start
+
+### 3. Zone Field (Not Label)
+
+**Decision:** Rename "label" field from Discord bot to "zone"
+
+**Rationale:**
+- More semantic and descriptive
+- "Zone" better describes location/assignment concept
+- Avoids confusion with UI labels/tags
+- Matches medical terminology (ER zones)
+
+**Data Mapping:**
+```
+Discord Bot → Website
+"A"  → Zone A  (Blue)
+"B"  → Zone B  (Red)
+"C"  → Zone C  (Amber)
+"D"  → Zone D  (Amber)
+"PA" → Zone PA (Emerald)
+"FT" → Zone FT (Purple)
+```
+
+### 4. Date as PostgreSQL DATE Type
+
+**Decision:** Use `@db.Date` instead of `DateTime`
+
+**Rationale:**
+- Shifts are day-based (not time-based)
+- Avoids timezone conversion issues
+- Simpler queries (`WHERE date = '2025-12-01'`)
+- Smaller storage footprint
+
+**Usage:**
+```typescript
+// Query shifts for a date
+const shifts = await prisma.shift.findMany({
+  where: {
+    date: new Date('2025-12-01')
+  }
+});
+```
+
+### 5. Unique Constraint on Composite Key
+
+**Decision:** Prevent duplicate shifts with composite unique index
+
+**Constraint:** `@@unique([date, zone, startTime, scribeId, providerId])`
+
+**Rationale:**
+- One person can't be in two places at once
+- Same zone/time can have multiple people (scribe + provider)
+- Prevents data corruption from double-syncing
+- Enables upsert operations (create or update)
+
+## Next Steps
+
+### Phase 2: API Layer (Next)
+
+**Endpoints to Create:**
+```
+POST   /api/shifts/sync          # Sync shifts from scraper
+GET    /api/shifts               # Query shifts by date
+GET    /api/shifts/current       # Currently working
+GET    /api/shifts/range         # Date range query
+POST   /api/shifts/refresh       # Manual refresh (admin)
+```
+
+**Features:**
+- Authentication for admin endpoints
+- Change detection and notifications
+- Scribe/provider fuzzy matching
+- Data validation
+- Rate limiting
+
+### Phase 3: Frontend Integration
+
+**Components:**
+- Update `ScheduleCalendar.tsx` with real data
+- Create minimalistic Apple-inspired shift cards
+- Add daily detail view
+- Implement "currently working" widget
+- Zone color coding
+
+### Phase 4: Python Scraper Integration
+
+**Implementation:**
+- Keep Python scraper on Railway as separate service
+- POST scraped data to `/api/shifts/sync` endpoint
+- Authenticate with API key
+- Handle errors and retries
+
+### Phase 5: Automation
+
+**Features:**
+- Scheduled refresh (12-hour cycle)
+- Change detection alerts
+- Admin dashboard
+- Monitoring and logging
+
+## Testing Checklist
+
+Before moving to Phase 2, verify:
+
+- [ ] Vercel Postgres database created
+- [ ] `DATABASE_URL` environment variable set
+- [ ] Deploy to Vercel (or run locally)
+- [ ] Check deployment logs for migration success
+- [ ] Open Prisma Studio: `npx prisma studio`
+- [ ] Verify Scribe and Shift tables exist
+- [ ] Check indexes are created
+- [ ] Verify foreign key constraints work
+
+## SQL Migration Details
+
+The migration creates:
+
+**Tables:**
+- `Scribe` - 3 columns + timestamps
+- `Shift` - 8 columns + timestamps
+
+**Indexes:**
+- `Scribe_name_key` (UNIQUE)
+- `Scribe_name_idx`
+- `Shift_date_idx`
+- `Shift_scribeId_date_idx`
+- `Shift_providerId_date_idx`
+- `Shift_date_zone_startTime_scribeId_providerId_key` (UNIQUE)
+
+**Foreign Keys:**
+- `Shift.scribeId` → `Scribe.id` (SET NULL on delete)
+- `Shift.providerId` → `Provider.id` (SET NULL on delete)
+
+**Design Choice:** `SET NULL` instead of `CASCADE` allows keeping shift records even if scribe/provider is deleted (historical data preservation).
+
+## Files Modified
+
+```
+scripts/run-migrations.js       # Added shift/scribe migration
+prisma/schema.prisma            # Added Scribe and Shift models
+docs/VERCEL_DATABASE_SETUP.md  # Database setup guide (new)
+docs/SHIFTGEN_PHASE1.md         # This file (new)
+```
+
+## Summary
+
+Phase 1 establishes a solid database foundation for ShiftGen integration:
+
+- ✅ **Database schema** designed and documented
+- ✅ **Automatic migrations** configured (no manual npx needed)
+- ✅ **Vercel Postgres** setup guide created
+- ✅ **Separate database** approach (not Railway bridge)
+- ✅ **Production-ready** with proper indexes and constraints
+
+The system is ready for Phase 2 (API development) whenever you're ready to proceed!
+
+---
+
+**Completed:** 2025-11-29
+**Next Phase:** API Layer Development

--- a/docs/VERCEL_DATABASE_SETUP.md
+++ b/docs/VERCEL_DATABASE_SETUP.md
@@ -1,0 +1,259 @@
+# Vercel Postgres Database Setup
+
+This guide explains how to set up the PostgreSQL database for the Scribe Dashboard using Vercel Postgres.
+
+## Overview
+
+The Scribe Dashboard uses **automatic migrations** that run on every deployment and startup. You don't need to run any manual `npx` commands - the database tables are created and updated automatically.
+
+## Setting Up Vercel Postgres
+
+### 1. Create a Vercel Postgres Database
+
+1. Go to your [Vercel Dashboard](https://vercel.com/dashboard)
+2. Navigate to the **Storage** tab
+3. Click **Create Database**
+4. Select **Postgres**
+5. Choose a name (e.g., `scribe-database`)
+6. Select a region (choose closest to your users)
+7. Click **Create**
+
+### 2. Connect to Your Project
+
+Vercel automatically creates environment variables for your database:
+
+1. Go to your project's **Settings** → **Environment Variables**
+2. You should see `POSTGRES_URL`, `POSTGRES_PRISMA_URL`, and other database variables
+3. The `DATABASE_URL` variable should be automatically set to `POSTGRES_PRISMA_URL`
+4. If `DATABASE_URL` is not set, add it manually:
+   - **Name:** `DATABASE_URL`
+   - **Value:** Copy the value from `POSTGRES_PRISMA_URL`
+   - **Environments:** Production, Preview, Development
+
+### 3. Deploy Your Application
+
+That's it! When you deploy your application:
+
+1. Vercel will automatically set the database environment variables
+2. On build (`npm run build`), migrations will run automatically
+3. On startup (`npm run start`), migrations will verify the database is up to date
+4. All tables, indexes, and constraints will be created automatically
+
+## How It Works
+
+### Automatic Migrations
+
+The `scripts/run-migrations.js` file contains all database migrations as **idempotent SQL**. This means:
+
+- ✅ Safe to run multiple times
+- ✅ Won't break if tables already exist
+- ✅ Automatically creates missing tables
+- ✅ Automatically adds missing columns/indexes
+- ✅ No manual intervention required
+
+### Build Process
+
+The build process is defined in `package.json`:
+
+```json
+{
+  "scripts": {
+    "build": "npm run migrate && prisma generate && next build",
+    "start": "npm run migrate && next start",
+    "dev": "npm run migrate && next dev --turbo",
+    "migrate": "node scripts/run-migrations.js"
+  }
+}
+```
+
+Every time you run `npm run build`, `npm run start`, or `npm run dev`:
+1. Migrations run first (`npm run migrate`)
+2. Database tables are created/updated
+3. Prisma client is generated
+4. Application starts
+
+## Local Development
+
+### Option 1: Use Vercel Postgres Locally
+
+1. Install Vercel CLI: `npm i -g vercel`
+2. Link your project: `vercel link`
+3. Pull environment variables: `vercel env pull .env.local`
+4. Run dev server: `npm run dev`
+
+The migrations will automatically connect to your Vercel Postgres database.
+
+### Option 2: Use Local PostgreSQL
+
+1. Install PostgreSQL locally
+2. Create a database: `createdb scribe-dev`
+3. Create `.env.local` file:
+   ```
+   DATABASE_URL="postgresql://username:password@localhost:5432/scribe-dev"
+   ```
+4. Run dev server: `npm run dev`
+
+The migrations will automatically create all tables.
+
+## Database Management
+
+### Viewing Data
+
+**Option 1: Vercel Dashboard**
+- Go to **Storage** → Your database → **Data**
+- Browse tables and run SQL queries
+
+**Option 2: Prisma Studio**
+```bash
+npx prisma studio
+```
+Opens a visual database browser at http://localhost:5555
+
+### Checking Migration Status
+
+When you run the app, you'll see migration logs:
+
+```
+========================================
+🔄 MIGRATION SCRIPT STARTED
+========================================
+
+✓ Using DATABASE_URL
+  Connection string: postgresql://****@****
+
+📡 Testing database connection...
+✓ Database connection successful
+  Database: scribe-db
+  User: postgres
+  PostgreSQL: PostgreSQL 15.x
+
+🔧 Applying migrations...
+
+➜ Migration: 20251129000000_add_shift_and_scribe_tables
+  ✅ Completed in 45ms
+
+========================================
+✅ Migration Summary:
+   10 succeeded
+   0 failed
+========================================
+```
+
+## ShiftGen Integration
+
+The Shift and Scribe tables were added specifically for ShiftGen integration:
+
+### Scribe Table
+- Stores scribe information
+- Links to shifts via one-to-many relationship
+- Supports name standardization
+
+### Shift Table
+- Stores shift schedules
+- Links to both scribes and providers
+- Stores date (DATE type), zone, times, and site
+- Indexed for fast queries by date and person
+
+### Usage Example
+
+The Discord bot's Python scraper can POST data to an API endpoint (to be created in Phase 2):
+
+```python
+import requests
+
+shifts = [
+    {
+        "date": "2025-12-01",
+        "zone": "A",
+        "startTime": "0800",
+        "endTime": "1600",
+        "site": "St Joseph Scribe",
+        "scribeName": "Isaac",
+        "providerName": "Dr. Merjanian"
+    }
+]
+
+response = requests.post(
+    "https://your-site.vercel.app/api/shifts/sync",
+    json={"shifts": shifts},
+    headers={"Authorization": f"Bearer {API_KEY}"}
+)
+```
+
+The API endpoint will:
+1. Find or create the scribe
+2. Find the provider by name
+3. Upsert the shift (create or update)
+4. Return sync summary
+
+## Troubleshooting
+
+### "No database URL found"
+
+**Problem:** Migrations skip because `DATABASE_URL` is not set
+
+**Solution:**
+1. Check environment variables: `echo $DATABASE_URL`
+2. In Vercel: Settings → Environment Variables → Add `DATABASE_URL`
+3. Locally: Create `.env.local` with `DATABASE_URL=...`
+
+### "Connection timeout"
+
+**Problem:** Cannot connect to database
+
+**Solution:**
+1. Check database is running (Vercel Postgres dashboard)
+2. Verify connection string is correct
+3. Check firewall/network settings
+4. Try connecting from Vercel Postgres dashboard's SQL editor
+
+### "Migration failed"
+
+**Problem:** SQL error during migration
+
+**Solution:**
+1. Check error message in logs
+2. Verify database user has CREATE TABLE permissions
+3. Check for conflicting table/index names
+4. Contact support if issue persists
+
+### "Prisma Client not generated"
+
+**Problem:** TypeScript errors about Prisma types
+
+**Solution:**
+```bash
+npx prisma generate
+```
+
+This regenerates the Prisma Client with the latest schema.
+
+## Security Best Practices
+
+1. ✅ **Never commit `.env` files** - Use `.env.local` for local dev
+2. ✅ **Use connection pooling** - Vercel Postgres includes pgBouncer
+3. ✅ **Restrict database access** - Only Vercel can connect (no public IP)
+4. ✅ **Use read-only credentials** - For client-side queries (if needed)
+5. ✅ **Enable SSL** - Vercel Postgres uses SSL by default
+
+## Next Steps
+
+Now that the database is set up:
+
+1. ✅ **Phase 1 Complete:** Database schema ready
+2. ⏳ **Phase 2:** Create API endpoints for shift data
+3. ⏳ **Phase 3:** Update calendar UI to display shifts
+4. ⏳ **Phase 4:** Integrate Python scraper with API
+5. ⏳ **Phase 5:** Add scheduled refresh automation
+
+## Support
+
+- **Vercel Docs:** https://vercel.com/docs/storage/vercel-postgres
+- **Prisma Docs:** https://www.prisma.io/docs
+- **Migration Issues:** Check `scripts/run-migrations.js` for SQL
+
+---
+
+**Last Updated:** 2025-11-29
+**Database Version:** PostgreSQL 15+
+**Migration System:** Custom idempotent SQL migrations

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,8 +30,9 @@ model Provider {
   viewCount        Int @default(0)  // Profile view tracking
   searchClickCount Int @default(0)  // Search click tracking
 
-  // New Page relationship
+  // Relationships
   page          Page?
+  shifts        Shift[]  @relation("ProviderShifts")
 
   // Metadata
   createdAt DateTime @default(now())
@@ -288,4 +289,43 @@ model User {
 enum UserRole {
   ADMIN
   EDITOR
+}
+
+model Scribe {
+  id               String   @id @default(cuid())
+  name             String   @unique
+  standardizedName String?  // Standardized name from name mapper
+
+  // Relationships
+  shifts           Shift[]  @relation("ScribeShifts")
+
+  // Metadata
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  @@index([name])
+}
+
+model Shift {
+  id        String   @id @default(cuid())
+  date      DateTime @db.Date
+  zone      String   // Zone identifier (A, B, C, PA, etc.)
+  startTime String   // e.g., "0800"
+  endTime   String   // e.g., "1600"
+  site      String   // Site name
+
+  // Relationships
+  scribeId     String?
+  scribe       Scribe?   @relation("ScribeShifts", fields: [scribeId], references: [id], onDelete: SetNull)
+  providerId   String?
+  provider     Provider? @relation("ProviderShifts", fields: [providerId], references: [id], onDelete: SetNull)
+
+  // Metadata
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([date, zone, startTime, scribeId, providerId])
+  @@index([date])
+  @@index([scribeId, date])
+  @@index([providerId, date])
 }


### PR DESCRIPTION
- Add Scribe and Shift models to Prisma schema
- Add automatic migration for shift/scribe tables
- Extend Provider model with shifts relation
- Create Vercel Postgres setup documentation
- Use separate Vercel DB instead of Railway bridge
- Support automatic migrations (no CLI needed)

This addresses database setup issues for ShiftGen integration. Works with Vercel web interface - no npx commands required.