### PR TITLE
fix: remove frozen-lockfile to allow pnpm lockfile regeneration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "installCommand": "pnpm install --frozen-lockfile",
+  "installCommand": "pnpm install",
   "framework": "nextjs",
   "regions": ["iad1"],
   "env": {


### PR DESCRIPTION
This allows Vercel to regenerate the pnpm-lock.yaml file during deployment to fix the ERR_PNPM_OUTDATED_LOCKFILE error.