### PR TITLE
feat: implement zone-based shift grouping and admin DB management

### DIFF
--- a/app/api/admin/db/clean-duplicates/route.ts
+++ b/app/api/admin/db/clean-duplicates/route.ts
@@ -1,0 +1,55 @@
+/**
+ * POST /api/admin/db/clean-duplicates
+ * Clean duplicate shifts from database
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { cleanDuplicateShifts } from '@/lib/shiftgen';
+
+export async function POST(request: NextRequest) {
+  try {
+    // Verify admin authentication (simple passcode check)
+    const authHeader = request.headers.get('authorization');
+    const adminPasscode = process.env.ADMIN_PASSCODE || '5150';
+
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'Missing or invalid authorization header',
+        },
+        { status: 401 }
+      );
+    }
+
+    const token = authHeader.substring(7);
+    if (token !== adminPasscode) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'Invalid passcode',
+        },
+        { status: 403 }
+      );
+    }
+
+    console.log('Cleaning duplicate shifts...');
+    const result = await cleanDuplicateShifts();
+
+    return NextResponse.json({
+      success: true,
+      data: result,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error('Error cleaning duplicates:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/db/reset/route.ts
+++ b/app/api/admin/db/reset/route.ts
@@ -1,0 +1,67 @@
+/**
+ * POST /api/admin/db/reset
+ * Reset database - delete all shifts (DANGEROUS!)
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { resetDatabase } from '@/lib/shiftgen';
+
+export async function POST(request: NextRequest) {
+  try {
+    // Verify admin authentication (simple passcode check)
+    const authHeader = request.headers.get('authorization');
+    const adminPasscode = process.env.ADMIN_PASSCODE || '5150';
+
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'Missing or invalid authorization header',
+        },
+        { status: 401 }
+      );
+    }
+
+    const token = authHeader.substring(7);
+    if (token !== adminPasscode) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'Invalid passcode',
+        },
+        { status: 403 }
+      );
+    }
+
+    // Require confirmation
+    const body = await request.json();
+    if (body.confirm !== 'RESET') {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'Confirmation required. Send { "confirm": "RESET" } in request body.',
+        },
+        { status: 400 }
+      );
+    }
+
+    console.log('RESETTING DATABASE - DELETING ALL SHIFTS...');
+    const result = await resetDatabase();
+
+    return NextResponse.json({
+      success: true,
+      data: result,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error('Error resetting database:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/db/stats/route.ts
+++ b/app/api/admin/db/stats/route.ts
@@ -1,0 +1,29 @@
+/**
+ * GET /api/admin/db/stats
+ * Get database statistics
+ */
+
+import { NextResponse } from 'next/server';
+import { getDatabaseStats } from '@/lib/shiftgen';
+
+export async function GET() {
+  try {
+    const stats = await getDatabaseStats();
+
+    return NextResponse.json({
+      success: true,
+      data: stats,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error('Error fetching database stats:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/shifts/daily/route.ts
+++ b/app/api/shifts/daily/route.ts
@@ -1,10 +1,10 @@
 /**
  * GET /api/shifts/daily?date=YYYY-MM-DD
- * Get daily schedule with time period grouping
+ * Get daily schedule with zone-based grouping
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { getDailySchedule, isValidDateFormat, ApiResponse, DailySchedule } from '@/lib/shiftgen';
+import { getDailyScheduleByZone, isValidDateFormat, ApiResponse, DailySchedule } from '@/lib/shiftgen';
 
 export async function GET(request: NextRequest) {
   try {
@@ -30,7 +30,7 @@ export async function GET(request: NextRequest) {
     }
 
     const date = new Date(dateParam);
-    const schedule = await getDailySchedule(date);
+    const schedule = await getDailyScheduleByZone(date);
 
     const response: ApiResponse<DailySchedule> = {
       success: true,

--- a/src/components/calendar/ScheduleCalendar.tsx
+++ b/src/components/calendar/ScheduleCalendar.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo, memo, useEffect } from 'react';
 import { Calendar, Lock, X } from 'lucide-react';
-import { getZoneStyles, formatShiftTime } from '@/lib/shiftgen';
+import { getZoneStyles, formatShiftTime, getZoneGroupLabel, type ZoneGroupedShifts } from '@/lib/shiftgen';
 import type { DailySchedule, ShiftWithRelations } from '@/lib/shiftgen';
 
 const PASSCODE = '5150'; // TODO: Move to environment variable or secure storage
@@ -62,10 +62,17 @@ function DailyModal({ date, dailySchedule, onClose }: DailyModalProps) {
     year: 'numeric',
   });
 
-  const hasShifts =
-    dailySchedule.shifts.morning.length > 0 ||
-    dailySchedule.shifts.afternoon.length > 0 ||
-    dailySchedule.shifts.night.length > 0;
+  // Check if using zone-based grouping
+  const shifts = dailySchedule.shifts as ZoneGroupedShifts;
+  const isZoneBased = 'zone1' in shifts;
+
+  const hasShifts = isZoneBased
+    ? (shifts.zone1?.length > 0 ||
+       shifts.zone2?.length > 0 ||
+       shifts.zones34?.length > 0 ||
+       shifts.zones56?.length > 0 ||
+       shifts.overflowPit?.length > 0)
+    : false;
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm">
@@ -95,46 +102,71 @@ function DailyModal({ date, dailySchedule, onClose }: DailyModalProps) {
               <p className="text-zinc-600 dark:text-zinc-400">No shifts scheduled for this day</p>
             </div>
           ) : (
-            <div className="space-y-6">
-              {/* Morning */}
-              {dailySchedule.shifts.morning.length > 0 && (
+            <div className="space-y-4">
+              {/* Zone 1 */}
+              {shifts.zone1 && shifts.zone1.length > 0 && (
                 <div>
-                  <h4 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 mb-3 flex items-center gap-2">
-                    <span className="text-lg">☀️</span>
-                    Morning Shifts
+                  <h4 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 mb-2 px-1">
+                    {getZoneGroupLabel('zone1')}
                   </h4>
                   <div className="space-y-2">
-                    {dailySchedule.shifts.morning.map((shift) => (
+                    {shifts.zone1.map((shift) => (
                       <ShiftCard key={shift.id} shift={shift} />
                     ))}
                   </div>
                 </div>
               )}
 
-              {/* Afternoon */}
-              {dailySchedule.shifts.afternoon.length > 0 && (
+              {/* Zone 2 */}
+              {shifts.zone2 && shifts.zone2.length > 0 && (
                 <div>
-                  <h4 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 mb-3 flex items-center gap-2">
-                    <span className="text-lg">🌤️</span>
-                    Afternoon Shifts
+                  <h4 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 mb-2 px-1">
+                    {getZoneGroupLabel('zone2')}
                   </h4>
                   <div className="space-y-2">
-                    {dailySchedule.shifts.afternoon.map((shift) => (
+                    {shifts.zone2.map((shift) => (
                       <ShiftCard key={shift.id} shift={shift} />
                     ))}
                   </div>
                 </div>
               )}
 
-              {/* Night */}
-              {dailySchedule.shifts.night.length > 0 && (
+              {/* Zones 3/4 */}
+              {shifts.zones34 && shifts.zones34.length > 0 && (
                 <div>
-                  <h4 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 mb-3 flex items-center gap-2">
-                    <span className="text-lg">🌙</span>
-                    Night Shifts
+                  <h4 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 mb-2 px-1">
+                    {getZoneGroupLabel('zones34')}
                   </h4>
                   <div className="space-y-2">
-                    {dailySchedule.shifts.night.map((shift) => (
+                    {shifts.zones34.map((shift) => (
+                      <ShiftCard key={shift.id} shift={shift} />
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Zones 5/6 */}
+              {shifts.zones56 && shifts.zones56.length > 0 && (
+                <div>
+                  <h4 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 mb-2 px-1">
+                    {getZoneGroupLabel('zones56')}
+                  </h4>
+                  <div className="space-y-2">
+                    {shifts.zones56.map((shift) => (
+                      <ShiftCard key={shift.id} shift={shift} />
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Overflow/PIT */}
+              {shifts.overflowPit && shifts.overflowPit.length > 0 && (
+                <div>
+                  <h4 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 mb-2 px-1">
+                    {getZoneGroupLabel('overflowPit')}
+                  </h4>
+                  <div className="space-y-2">
+                    {shifts.overflowPit.map((shift) => (
                       <ShiftCard key={shift.id} shift={shift} />
                     ))}
                   </div>

--- a/src/lib/shiftgen/constants.ts
+++ b/src/lib/shiftgen/constants.ts
@@ -10,10 +10,11 @@ import { ZoneConfig } from './types';
  * Replaces Discord bot's color emoji system with subtle design
  */
 export const ZONE_CONFIGS: Record<string, ZoneConfig> = {
+  // Zone 1: A, E, I
   A: {
     id: 'A',
     label: 'Zone 1',
-    description: 'Zone 1 (Blue)',
+    description: 'Zone 1 - A Shift',
     color: 'blue',
     styles: {
       border: 'border-l-4 border-blue-500/30',
@@ -22,10 +23,35 @@ export const ZONE_CONFIGS: Record<string, ZoneConfig> = {
       badge: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-200',
     },
   },
+  E: {
+    id: 'E',
+    label: 'Zone 1',
+    description: 'Zone 1 - E Shift',
+    color: 'blue',
+    styles: {
+      border: 'border-l-4 border-blue-500/30',
+      bg: 'bg-blue-500/5 hover:bg-blue-500/10',
+      text: 'text-blue-900 dark:text-blue-100',
+      badge: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-200',
+    },
+  },
+  I: {
+    id: 'I',
+    label: 'Zone 1',
+    description: 'Zone 1 - I Shift',
+    color: 'blue',
+    styles: {
+      border: 'border-l-4 border-blue-500/30',
+      bg: 'bg-blue-500/5 hover:bg-blue-500/10',
+      text: 'text-blue-900 dark:text-blue-100',
+      badge: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-200',
+    },
+  },
+  // Zone 2: B, F, X
   B: {
     id: 'B',
     label: 'Zone 2',
-    description: 'Zone 2 (Red)',
+    description: 'Zone 2 - B Shift',
     color: 'red',
     styles: {
       border: 'border-l-4 border-red-500/30',
@@ -34,10 +60,35 @@ export const ZONE_CONFIGS: Record<string, ZoneConfig> = {
       badge: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-200',
     },
   },
+  F: {
+    id: 'F',
+    label: 'Zone 2',
+    description: 'Zone 2 - F Shift',
+    color: 'red',
+    styles: {
+      border: 'border-l-4 border-red-500/30',
+      bg: 'bg-red-500/5 hover:bg-red-500/10',
+      text: 'text-red-900 dark:text-red-100',
+      badge: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-200',
+    },
+  },
+  X: {
+    id: 'X',
+    label: 'Zone 2',
+    description: 'Zone 2 - X Shift',
+    color: 'red',
+    styles: {
+      border: 'border-l-4 border-red-500/30',
+      bg: 'bg-red-500/5 hover:bg-red-500/10',
+      text: 'text-red-900 dark:text-red-100',
+      badge: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-200',
+    },
+  },
+  // Zones 3/4: C, G
   C: {
     id: 'C',
-    label: 'Zone 3/4',
-    description: 'Zone 3/4 (Amber)',
+    label: 'Zones 3/4',
+    description: 'Zones 3/4 - C Shift',
     color: 'amber',
     styles: {
       border: 'border-l-4 border-amber-500/30',
@@ -46,10 +97,23 @@ export const ZONE_CONFIGS: Record<string, ZoneConfig> = {
       badge: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-200',
     },
   },
-  PA: {
-    id: 'PA',
-    label: 'PA/NP',
-    description: 'PA/NP (Emerald)',
+  G: {
+    id: 'G',
+    label: 'Zones 3/4',
+    description: 'Zones 3/4 - G Shift',
+    color: 'amber',
+    styles: {
+      border: 'border-l-4 border-amber-500/30',
+      bg: 'bg-amber-500/5 hover:bg-amber-500/10',
+      text: 'text-amber-900 dark:text-amber-100',
+      badge: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-200',
+    },
+  },
+  // Zones 5/6: D, H, PA
+  D: {
+    id: 'D',
+    label: 'Zones 5/6',
+    description: 'Zones 5/6 - D Shift',
     color: 'emerald',
     styles: {
       border: 'border-l-4 border-emerald-500/30',
@@ -58,10 +122,35 @@ export const ZONE_CONFIGS: Record<string, ZoneConfig> = {
       badge: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-200',
     },
   },
-  FT: {
-    id: 'FT',
-    label: 'Fast Track',
-    description: 'Fast Track (Purple)',
+  H: {
+    id: 'H',
+    label: 'Zones 5/6',
+    description: 'Zones 5/6 - H Shift',
+    color: 'emerald',
+    styles: {
+      border: 'border-l-4 border-emerald-500/30',
+      bg: 'bg-emerald-500/5 hover:bg-emerald-500/10',
+      text: 'text-emerald-900 dark:text-emerald-100',
+      badge: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-200',
+    },
+  },
+  PA: {
+    id: 'PA',
+    label: 'Zones 5/6',
+    description: 'Zones 5/6 - PA Shift',
+    color: 'emerald',
+    styles: {
+      border: 'border-l-4 border-emerald-500/30',
+      bg: 'bg-emerald-500/5 hover:bg-emerald-500/10',
+      text: 'text-emerald-900 dark:text-emerald-100',
+      badge: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-200',
+    },
+  },
+  // Overflow/PIT
+  PIT: {
+    id: 'PIT',
+    label: 'Overflow/PIT',
+    description: 'Overflow/PIT',
     color: 'purple',
     styles: {
       border: 'border-l-4 border-purple-500/30',
@@ -94,6 +183,56 @@ export function getZoneConfig(zoneId: string): ZoneConfig {
 export function getZoneStyles(zoneId: string) {
   const config = getZoneConfig(zoneId);
   return config.styles;
+}
+
+/**
+ * Map shift zone to zone group for grouping
+ */
+export function getZoneGroupForShift(zone: string): 'zone1' | 'zone2' | 'zones34' | 'zones56' | 'overflowPit' {
+  const zoneUpper = zone.toUpperCase();
+
+  if (['A', 'E', 'I'].includes(zoneUpper)) {
+    return 'zone1';
+  } else if (['B', 'F', 'X'].includes(zoneUpper)) {
+    return 'zone2';
+  } else if (['C', 'G'].includes(zoneUpper)) {
+    return 'zones34';
+  } else if (['D', 'H', 'PA'].includes(zoneUpper)) {
+    return 'zones56';
+  } else if (zoneUpper === 'PIT') {
+    return 'overflowPit';
+  }
+
+  // Default to zone1 for unknown zones
+  return 'zone1';
+}
+
+/**
+ * Get display label for zone group
+ */
+export function getZoneGroupLabel(group: 'zone1' | 'zone2' | 'zones34' | 'zones56' | 'overflowPit'): string {
+  const labels = {
+    zone1: 'Zone 1',
+    zone2: 'Zone 2',
+    zones34: 'Zones 3/4',
+    zones56: 'Zones 5/6',
+    overflowPit: 'Overflow/PIT',
+  };
+  return labels[group];
+}
+
+/**
+ * Get shift order within zone (for sorting)
+ */
+export function getShiftOrderInZone(zone: string): number {
+  const order: Record<string, number> = {
+    A: 0, E: 1, I: 2,       // Zone 1
+    B: 0, F: 1, X: 2,       // Zone 2
+    C: 0, G: 1,             // Zones 3/4
+    D: 0, H: 1, PA: 2,      // Zones 5/6
+    PIT: 0,                 // Overflow/PIT
+  };
+  return order[zone.toUpperCase()] ?? 99;
 }
 
 /**

--- a/src/lib/shiftgen/index.ts
+++ b/src/lib/shiftgen/index.ts
@@ -8,6 +8,8 @@ export type {
   ShiftWithRelations,
   TimePeriod,
   GroupedShifts,
+  ZoneGroupedShifts,
+  ZoneGroup,
   DailySchedule,
   CurrentShifts,
   ZoneConfig,
@@ -21,6 +23,9 @@ export {
   TIME_PERIODS,
   getZoneConfig,
   getZoneStyles,
+  getZoneGroupForShift,
+  getZoneGroupLabel,
+  getShiftOrderInZone,
   parseTime,
   formatTime,
   formatShiftTime,
@@ -37,6 +42,7 @@ export {
   getShiftsInRange,
   getCurrentShifts,
   getDailySchedule,
+  getDailyScheduleByZone,
   findScribeByName,
   findProviderByName,
   createShift,
@@ -48,6 +54,9 @@ export {
   getAllScribes,
   getShiftsByScribe,
   getShiftsByProvider,
+  cleanDuplicateShifts,
+  resetDatabase,
+  getDatabaseStats,
 } from './db';
 
 // Server-only exports (contain Node.js dependencies like 'fs')

--- a/src/lib/shiftgen/types.ts
+++ b/src/lib/shiftgen/types.ts
@@ -14,12 +14,17 @@ export type ShiftWithRelations = Shift & {
 };
 
 /**
- * Time period for grouping shifts
+ * Time period for grouping shifts (deprecated, keeping for backwards compatibility)
  */
 export type TimePeriod = 'morning' | 'afternoon' | 'night';
 
 /**
- * Shifts grouped by time period
+ * Zone-based grouping for ED zones
+ */
+export type ZoneGroup = 'zone1' | 'zone2' | 'zones34' | 'zones56' | 'overflowPit';
+
+/**
+ * Shifts grouped by time period (deprecated)
  */
 export type GroupedShifts = {
   morning: ShiftWithRelations[];
@@ -28,11 +33,22 @@ export type GroupedShifts = {
 };
 
 /**
+ * Shifts grouped by ED zone
+ */
+export type ZoneGroupedShifts = {
+  zone1: ShiftWithRelations[];      // A, E, I
+  zone2: ShiftWithRelations[];      // B, F, X
+  zones34: ShiftWithRelations[];    // C, G
+  zones56: ShiftWithRelations[];    // D, H, PA
+  overflowPit: ShiftWithRelations[]; // PIT
+};
+
+/**
  * Daily schedule with summary
  */
 export type DailySchedule = {
   date: Date;
-  shifts: GroupedShifts;
+  shifts: GroupedShifts | ZoneGroupedShifts;
   summary: {
     totalShifts: number;
     uniqueScribes: number;


### PR DESCRIPTION
- Replace time-based grouping (morning/afternoon/night) with zone-based grouping
- Update zone mappings per ED structure:
  * Zone 1: A, E, I
  * Zone 2: B, F, X
  * Zones 3/4: C, G
  * Zones 5/6: D, H, PA
  * Overflow/PIT: PIT
- Redesign calendar modal UI with Apple-inspired minimalist design
- Add zone-based sorting and display logic
- Create admin panel database management features:
  * Database statistics dashboard
  * Clean duplicate shifts functionality
  * Reset database functionality (with confirmation)
- Add new API routes for database operations
- Update types and constants to support zone-based grouping