### PR TITLE
feat: add Shift Management card to admin dashboard

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -103,6 +103,18 @@ export default function AdminPage() {
           </a>
 
           <a
+            href="/admin/shifts"
+            className="group bg-blue-950/30 border border-blue-900/30 rounded-xl p-6 hover:bg-blue-950/50 hover:border-blue-800/40 transition-all duration-150 block"
+          >
+            <h2 className="text-lg font-semibold text-blue-400 mb-2 group-hover:text-blue-300 transition-colors">
+              Shift Management
+            </h2>
+            <p className="text-sm text-zinc-400 leading-relaxed">
+              Manage shift database, scraping, and maintenance
+            </p>
+          </a>
+
+          <a
             href="/admin/animated-messages"
             className="group bg-zinc-900 border border-zinc-800 rounded-xl p-6 hover:bg-zinc-800/50 hover:border-zinc-700 transition-all duration-150 block"
           >


### PR DESCRIPTION
- Add prominent link to /admin/shifts from main admin dashboard
- Blue-highlighted card makes DB management features discoverable
- Allows access to shift database stats, duplicate cleaning, and reset functionality