### PR TITLE
fix: add providerName and providerRole to RawShiftData type

### DIFF
--- a/src/lib/shiftgen/parser.ts
+++ b/src/lib/shiftgen/parser.ts
@@ -13,6 +13,8 @@ export interface RawShiftData {
   person: string;    // Name
   role: string;      // Scribe, Physician, or MLP
   site: string;      // Site name
+  providerName?: string;  // Provider name (populated during matching)
+  providerRole?: string;  // Provider role (populated during matching)
 }
 
 export class ScheduleParser {


### PR DESCRIPTION
TypeScript compilation was failing because the sync service was trying to add providerName and providerRole properties to RawShiftData objects, but these fields weren't defined in the interface. Added them as optional fields since they are populated during the provider matching process.