### PR TITLE
fix: auto-create provider records during shift sync

### DIFF
--- a/src/lib/shiftgen/db.ts
+++ b/src/lib/shiftgen/db.ts
@@ -297,6 +297,23 @@ export async function findOrCreateScribe(name: string, standardizedName?: string
 }
 
 /**
+ * Create or find provider by name
+ */
+export async function findOrCreateProvider(name: string) {
+  let provider = await findProviderByName(name);
+
+  if (!provider) {
+    provider = await prisma.provider.create({
+      data: {
+        name,
+      },
+    });
+  }
+
+  return provider;
+}
+
+/**
  * Upsert shift (create or update)
  */
 export async function upsertShift(data: {

--- a/src/lib/shiftgen/index.ts
+++ b/src/lib/shiftgen/index.ts
@@ -50,6 +50,7 @@ export {
   deleteShift,
   deleteShiftsForDate,
   findOrCreateScribe,
+  findOrCreateProvider,
   upsertShift,
   getAllScribes,
   getShiftsByScribe,

--- a/src/lib/shiftgen/sync.ts
+++ b/src/lib/shiftgen/sync.ts
@@ -8,7 +8,7 @@ import { ShiftGenScraper } from './scraper';
 import { ScheduleParser, RawShiftData } from './parser';
 import { NameMapper } from './name-mapper';
 import { SITES_TO_FETCH, SITE_CHANGE_DELAY, PAGE_LOAD_DELAY } from './config';
-import { findOrCreateScribe, findProviderByName, upsertShift } from './db';
+import { findOrCreateScribe, findOrCreateProvider, upsertShift } from './db';
 
 export interface SyncResult {
   success: boolean;
@@ -231,15 +231,15 @@ export class ShiftGenSyncService {
     const scribe = await findOrCreateScribe(shift.person, scribeStandardizedName);
     const scribeId = scribe.id;
 
-    // Find provider if matched
+    // Find or create provider if matched
     let providerId: string | null = null;
     if (shift.providerName && shift.providerRole) {
       const providerStandardizedName = this.nameMapper.standardizeName(
         shift.providerName,
         shift.providerRole
       );
-      const provider = await findProviderByName(providerStandardizedName);
-      providerId = provider?.id || null;
+      const provider = await findOrCreateProvider(providerStandardizedName);
+      providerId = provider.id;
     }
 
     // Upsert shift


### PR DESCRIPTION
Previously, the sync service would match scribes with providers but fail to create provider records if they didn't already exist in the database. This caused shifts to be saved without provider information (providerId = null).

Changes:
- Add findOrCreateProvider() function to db.ts
- Update sync service to use findOrCreateProvider() instead of findProviderByName()
- Export findOrCreateProvider from shiftgen/index.ts

Now when shifts are scraped, providers will be automatically created if they don't exist, ensuring the calendar displays 'Scribe with Provider' information correctly.