### PR TITLE
fix: prevent duplicate shifts and missing providers in calendar

### DIFF
--- a/prisma/migrations/20251202000000_fix_shift_unique_constraint/migration.sql
+++ b/prisma/migrations/20251202000000_fix_shift_unique_constraint/migration.sql
@@ -1,0 +1,17 @@
+-- Drop the old unique constraint
+ALTER TABLE "Shift" DROP CONSTRAINT IF EXISTS "Shift_date_zone_startTime_scribeId_providerId_key";
+
+-- Remove duplicate shifts, keeping only the most recent one for each (date, zone, startTime) combination
+DELETE FROM "Shift" a USING (
+  SELECT MIN(ctid) as ctid, date, zone, "startTime"
+  FROM "Shift"
+  GROUP BY date, zone, "startTime"
+  HAVING COUNT(*) > 1
+) b
+WHERE a.date = b.date
+  AND a.zone = b.zone
+  AND a."startTime" = b."startTime"
+  AND a.ctid <> b.ctid;
+
+-- Add the new unique constraint
+ALTER TABLE "Shift" ADD CONSTRAINT "Shift_date_zone_startTime_key" UNIQUE (date, zone, "startTime");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -324,7 +324,7 @@ model Shift {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  @@unique([date, zone, startTime, scribeId, providerId])
+  @@unique([date, zone, startTime])
   @@index([date])
   @@index([scribeId, date])
   @@index([providerId, date])


### PR DESCRIPTION
- Change unique constraint from (date, zone, startTime, scribeId, providerId) to (date, zone, startTime)
- Update upsertShift to search only by unique constraint fields
- Conditionally update scribeId/providerId to preserve data
- Add migration to remove existing duplicates and apply new constraint

This fixes the issue where multiple scribes appeared for the same shift slot and providers were not being displayed alongside scribes.