### PR TITLE
fix: improve shift upsert logic and enhance debug endpoint

### DIFF
--- a/app/api/debug/shifts/route.ts
+++ b/app/api/debug/shifts/route.ts
@@ -1,15 +1,32 @@
 /**
  * DEBUG ENDPOINT - GET /api/debug/shifts
  * Inspect raw shift data from database
+ *
+ * Query params:
+ * - date: Filter by specific date (YYYY-MM-DD)
+ * - detailed: Show detailed view (true/false)
  */
 
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
+    const { searchParams } = new URL(request.url);
+    const dateFilter = searchParams.get('date');
+    const detailed = searchParams.get('detailed') === 'true';
+
+    // Build where clause
+    const where: any = {};
+    if (dateFilter) {
+      const [year, month, day] = dateFilter.split('-').map(Number);
+      const filterDate = new Date(Date.UTC(year, month - 1, day, 0, 0, 0, 0));
+      where.date = filterDate;
+    }
+
     // Get all shifts with their relations
     const shifts = await prisma.shift.findMany({
+      where,
       include: {
         scribe: true,
         provider: true,
@@ -33,15 +50,21 @@ export async function GET() {
         zone: shift.zone,
         startTime: shift.startTime,
         endTime: shift.endTime,
+        site: shift.site,
         scribe: shift.scribe ? {
+          id: shift.scribeId,
           name: shift.scribe.name,
           standardizedName: shift.scribe.standardizedName,
         } : null,
         provider: shift.provider ? {
+          id: shift.providerId,
           name: shift.provider.name,
+          slug: shift.provider.slug,
         } : null,
         hasScribe: !!shift.scribeId,
         hasProvider: !!shift.providerId,
+        createdAt: shift.createdAt.toISOString(),
+        updatedAt: shift.updatedAt.toISOString(),
       });
       return acc;
     }, {} as Record<string, any[]>);
@@ -61,16 +84,85 @@ export async function GET() {
       withProvider: shifts.filter(s => s.providerId).length,
       withBoth: shifts.filter(s => s.scribeId && s.providerId).length,
       withNeither: shifts.filter(s => !s.scribeId && !s.providerId).length,
+      scribeOnly: shifts.filter(s => s.scribeId && !s.providerId).length,
+      providerOnly: shifts.filter(s => !s.scribeId && s.providerId).length,
     };
 
-    return NextResponse.json({
+    // Get counts by zone
+    const byZone = shifts.reduce((acc, shift) => {
+      if (!acc[shift.zone]) {
+        acc[shift.zone] = {
+          total: 0,
+          withScribe: 0,
+          withProvider: 0,
+          withBoth: 0,
+        };
+      }
+      acc[shift.zone].total++;
+      if (shift.scribeId) acc[shift.zone].withScribe++;
+      if (shift.providerId) acc[shift.zone].withProvider++;
+      if (shift.scribeId && shift.providerId) acc[shift.zone].withBoth++;
+      return acc;
+    }, {} as Record<string, any>);
+
+    // Check for duplicates (multiple shifts for same slot)
+    const duplicates: any[] = [];
+    const seen = new Map<string, any[]>();
+    for (const shift of shifts) {
+      const key = `${shift.date.toISOString().split('T')[0]}-${shift.zone}-${shift.startTime}`;
+      if (!seen.has(key)) {
+        seen.set(key, []);
+      }
+      seen.get(key)!.push({
+        id: shift.id,
+        scribe: shift.scribe?.name,
+        provider: shift.provider?.name,
+      });
+    }
+    for (const [key, group] of seen.entries()) {
+      if (group.length > 1) {
+        duplicates.push({
+          slot: key,
+          count: group.length,
+          shifts: group,
+        });
+      }
+    }
+
+    const response: any = {
       success: true,
       stats,
+      byZone,
       dateRange,
-      shiftsByDate,
-      sampleShifts: shifts.slice(0, 10),
+      duplicates: {
+        count: duplicates.length,
+        examples: duplicates.slice(0, 10),
+      },
       timestamp: new Date().toISOString(),
-    });
+    };
+
+    if (detailed) {
+      response.shiftsByDate = shiftsByDate;
+      response.allShifts = shifts.map(s => ({
+        id: s.id,
+        date: s.date.toISOString().split('T')[0],
+        zone: s.zone,
+        time: `${s.startTime}-${s.endTime}`,
+        scribe: s.scribe?.name || null,
+        provider: s.provider?.name || null,
+      }));
+    } else {
+      response.sampleShifts = shifts.slice(0, 20).map(s => ({
+        id: s.id,
+        date: s.date.toISOString().split('T')[0],
+        zone: s.zone,
+        time: `${s.startTime}-${s.endTime}`,
+        scribe: s.scribe?.name || null,
+        provider: s.provider?.name || null,
+      }));
+    }
+
+    return NextResponse.json(response);
   } catch (error) {
     console.error('Error fetching debug shifts:', error);
     return NextResponse.json(

--- a/src/lib/shiftgen/db.ts
+++ b/src/lib/shiftgen/db.ts
@@ -364,17 +364,25 @@ export async function upsertShift(data: {
 
   if (existing) {
     // Update existing shift with new information
-    // Only update fields if they have values (don't overwrite with null)
+    // Build update data object
+    const updateData: any = {
+      endTime: data.endTime,
+      site: data.site,
+    };
+
+    // Update scribeId if provided (including explicit null to clear it)
+    if (data.scribeId !== undefined) {
+      updateData.scribeId = data.scribeId;
+    }
+
+    // Update providerId if provided (including explicit null to clear it)
+    if (data.providerId !== undefined) {
+      updateData.providerId = data.providerId;
+    }
+
     const updated = await prisma.shift.update({
       where: { id: existing.id },
-      data: {
-        endTime: data.endTime,
-        site: data.site,
-        // Only update scribeId if provided
-        ...(data.scribeId && { scribeId: data.scribeId }),
-        // Only update providerId if provided
-        ...(data.providerId && { providerId: data.providerId }),
-      },
+      data: updateData,
       include: {
         scribe: true,
         provider: true,


### PR DESCRIPTION
- Fix upsertShift to properly handle null values in updates
  - Old code only updated fields if truthy (data.scribeId && ...)
  - New code checks if undefined vs null, allowing proper updates
  - This ensures matched shifts update existing records correctly

- Enhance debug endpoint (/api/debug/shifts)
  - Add date filtering query param (?date=YYYY-MM-DD)
  - Add detailed view query param (?detailed=true)
  - Show statistics broken down by zone
  - Detect and report duplicate shifts
  - Include more metadata (createdAt, updatedAt, IDs)
  - Better sample data formatting

This fixes issues where provider assignments weren't being saved to the database correctly during shift sync.