### PR TITLE
fix: correct zone mappings and add shift normalization for provider m…

### DIFF
--- a/src/lib/shiftgen/constants.ts
+++ b/src/lib/shiftgen/constants.ts
@@ -10,60 +10,48 @@ import { ZoneConfig } from './types';
  * Replaces Discord bot's color emoji system with subtle design
  */
 export const ZONE_CONFIGS: Record<string, ZoneConfig> = {
-  // Zone 1: A, E, I
-  A: {
-    id: 'A',
-    label: 'Zone 1',
-    description: 'Zone 1 - A Shift',
-    color: 'blue',
-    styles: {
-      border: 'border-l-4 border-blue-500/30',
-      bg: 'bg-blue-500/5 hover:bg-blue-500/10',
-      text: 'text-blue-900 dark:text-blue-100',
-      badge: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-200',
-    },
-  },
-  E: {
-    id: 'E',
-    label: 'Zone 1',
-    description: 'Zone 1 - E Shift',
-    color: 'blue',
-    styles: {
-      border: 'border-l-4 border-blue-500/30',
-      bg: 'bg-blue-500/5 hover:bg-blue-500/10',
-      text: 'text-blue-900 dark:text-blue-100',
-      badge: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-200',
-    },
-  },
-  I: {
-    id: 'I',
-    label: 'Zone 1',
-    description: 'Zone 1 - I Shift',
-    color: 'blue',
-    styles: {
-      border: 'border-l-4 border-blue-500/30',
-      bg: 'bg-blue-500/5 hover:bg-blue-500/10',
-      text: 'text-blue-900 dark:text-blue-100',
-      badge: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-200',
-    },
-  },
-  // Zone 2: B, F, X
+  // Zone 1: B, F, X
   B: {
     id: 'B',
-    label: 'Zone 2',
-    description: 'Zone 2 - B Shift',
-    color: 'red',
+    label: 'Zone 1',
+    description: 'Zone 1 - B Shift',
+    color: 'blue',
     styles: {
-      border: 'border-l-4 border-red-500/30',
-      bg: 'bg-red-500/5 hover:bg-red-500/10',
-      text: 'text-red-900 dark:text-red-100',
-      badge: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-200',
+      border: 'border-l-4 border-blue-500/30',
+      bg: 'bg-blue-500/5 hover:bg-blue-500/10',
+      text: 'text-blue-900 dark:text-blue-100',
+      badge: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-200',
     },
   },
   F: {
     id: 'F',
+    label: 'Zone 1',
+    description: 'Zone 1 - F Shift',
+    color: 'blue',
+    styles: {
+      border: 'border-l-4 border-blue-500/30',
+      bg: 'bg-blue-500/5 hover:bg-blue-500/10',
+      text: 'text-blue-900 dark:text-blue-100',
+      badge: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-200',
+    },
+  },
+  X: {
+    id: 'X',
+    label: 'Zone 1',
+    description: 'Zone 1 - X Shift',
+    color: 'blue',
+    styles: {
+      border: 'border-l-4 border-blue-500/30',
+      bg: 'bg-blue-500/5 hover:bg-blue-500/10',
+      text: 'text-blue-900 dark:text-blue-100',
+      badge: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-200',
+    },
+  },
+  // Zone 2: A, E, I
+  A: {
+    id: 'A',
     label: 'Zone 2',
-    description: 'Zone 2 - F Shift',
+    description: 'Zone 2 - A Shift',
     color: 'red',
     styles: {
       border: 'border-l-4 border-red-500/30',
@@ -72,10 +60,22 @@ export const ZONE_CONFIGS: Record<string, ZoneConfig> = {
       badge: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-200',
     },
   },
-  X: {
-    id: 'X',
+  E: {
+    id: 'E',
     label: 'Zone 2',
-    description: 'Zone 2 - X Shift',
+    description: 'Zone 2 - E Shift',
+    color: 'red',
+    styles: {
+      border: 'border-l-4 border-red-500/30',
+      bg: 'bg-red-500/5 hover:bg-red-500/10',
+      text: 'text-red-900 dark:text-red-100',
+      badge: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-200',
+    },
+  },
+  I: {
+    id: 'I',
+    label: 'Zone 2',
+    description: 'Zone 2 - I Shift',
     color: 'red',
     styles: {
       border: 'border-l-4 border-red-500/30',
@@ -191,9 +191,9 @@ export function getZoneStyles(zoneId: string) {
 export function getZoneGroupForShift(zone: string): 'zone1' | 'zone2' | 'zones34' | 'zones56' | 'overflowPit' {
   const zoneUpper = zone.toUpperCase();
 
-  if (['A', 'E', 'I'].includes(zoneUpper)) {
+  if (['B', 'F', 'X'].includes(zoneUpper)) {
     return 'zone1';
-  } else if (['B', 'F', 'X'].includes(zoneUpper)) {
+  } else if (['A', 'E', 'I'].includes(zoneUpper)) {
     return 'zone2';
   } else if (['C', 'G'].includes(zoneUpper)) {
     return 'zones34';
@@ -226,8 +226,8 @@ export function getZoneGroupLabel(group: 'zone1' | 'zone2' | 'zones34' | 'zones5
  */
 export function getShiftOrderInZone(zone: string): number {
   const order: Record<string, number> = {
-    A: 0, E: 1, I: 2,       // Zone 1
-    B: 0, F: 1, X: 2,       // Zone 2
+    B: 0, F: 1, X: 2,       // Zone 1
+    A: 0, E: 1, I: 2,       // Zone 2
     C: 0, G: 1,             // Zones 3/4
     D: 0, H: 1, PA: 2,      // Zones 5/6
     PIT: 0,                 // Overflow/PIT
@@ -335,4 +335,93 @@ export function normalizeDateToUTC(date: Date): Date {
     date.getUTCDate(),
     0, 0, 0, 0
   ));
+}
+
+/**
+ * Standard shift definitions
+ * Based on user's definitive shift times and zones
+ */
+interface ShiftDefinition {
+  letter: string;
+  startTime: string;  // HHMM format
+  endTime: string;    // HHMM format
+  zone: string;       // Zone label for display
+}
+
+export const SHIFT_DEFINITIONS: ShiftDefinition[] = [
+  { letter: 'A', startTime: '0530', endTime: '1400', zone: 'Zone 2' },
+  { letter: 'B', startTime: '0530', endTime: '1400', zone: 'Zone 1' },
+  { letter: 'C', startTime: '0900', endTime: '1800', zone: 'Zones 3/4' },
+  { letter: 'D', startTime: '1100', endTime: '1900', zone: 'Zones 5/6' },
+  { letter: 'E', startTime: '1330', endTime: '2230', zone: 'Zone 2' },
+  { letter: 'F', startTime: '1330', endTime: '2230', zone: 'Zone 1' },
+  { letter: 'G', startTime: '1730', endTime: '0230', zone: 'Zones 3/4' },
+  { letter: 'H', startTime: '1900', endTime: '0230', zone: 'Zones 5/6' },
+  { letter: 'I', startTime: '2200', endTime: '0600', zone: 'Zone 2' },
+  { letter: 'X', startTime: '2200', endTime: '0600', zone: 'Zone 1' },
+  { letter: 'PIT', startTime: '1230', endTime: '2030', zone: 'Overflow/PIT' },
+];
+
+/**
+ * Normalize time to 4-digit format (e.g., "800" -> "0800", "1400" -> "1400")
+ */
+function normalizeTimeFormat(time: string): string {
+  return time.padStart(4, '0');
+}
+
+/**
+ * Determine shift letter from start time and zone
+ * This helps match shifts even when labels differ between scribe/provider schedules
+ */
+export function getShiftLetterFromTime(startTime: string, rawLabel?: string): string | null {
+  const normalizedStart = normalizeTimeFormat(startTime);
+
+  // Special case: PA shifts can have multiple start times
+  if (rawLabel?.toUpperCase().includes('PA') || rawLabel?.toUpperCase().includes('MLP')) {
+    return 'PA';
+  }
+
+  // Special case: PIT shift
+  if (normalizedStart === '1230') {
+    return 'PIT';
+  }
+
+  // Try to match by start time alone first
+  const matchingShifts = SHIFT_DEFINITIONS.filter(def => def.startTime === normalizedStart);
+
+  if (matchingShifts.length === 1) {
+    return matchingShifts[0].letter;
+  }
+
+  // If multiple shifts have same start time, try to use the label to disambiguate
+  if (matchingShifts.length > 1 && rawLabel) {
+    const labelUpper = rawLabel.toUpperCase();
+
+    // Try exact letter match first
+    const exactMatch = matchingShifts.find(def => labelUpper.includes(def.letter));
+    if (exactMatch) {
+      return exactMatch.letter;
+    }
+
+    // Try zone-based matching
+    for (const def of matchingShifts) {
+      if (labelUpper.includes('ZONE 1') || labelUpper.includes('ZONE1')) {
+        if (def.zone === 'Zone 1') return def.letter;
+      }
+      if (labelUpper.includes('ZONE 2') || labelUpper.includes('ZONE2')) {
+        if (def.zone === 'Zone 2') return def.letter;
+      }
+    }
+  }
+
+  // Fallback: return first match if we have one
+  return matchingShifts.length > 0 ? matchingShifts[0].letter : null;
+}
+
+/**
+ * Get zone from shift letter
+ */
+export function getZoneFromShiftLetter(shiftLetter: string): string {
+  const shift = SHIFT_DEFINITIONS.find(def => def.letter.toUpperCase() === shiftLetter.toUpperCase());
+  return shift ? shift.letter : shiftLetter;
 }

--- a/src/lib/shiftgen/parser.ts
+++ b/src/lib/shiftgen/parser.ts
@@ -5,10 +5,12 @@
  */
 
 import * as cheerio from 'cheerio';
+import { getShiftLetterFromTime } from './constants';
 
 export interface RawShiftData {
   date: string;      // YYYY-MM-DD
   label: string;     // Zone identifier (A, B, C, PA, etc.)
+  rawLabel: string;  // Original label from HTML (for debugging)
   time: string;      // HHMM-HHMM
   person: string;    // Name
   role: string;      // Scribe, Physician, or MLP
@@ -224,10 +226,15 @@ export class ScheduleParser {
         const normalizedPerson = ScheduleParser.normalizePerson(person);
 
         // Skip empty shifts
-        if (normalizedPerson !== 'EMPTY') {
+        if (normalizedPerson !== 'EMPTY' && time) {
+          // Normalize shift letter using start time and raw label
+          const [startTime] = time.split('-');
+          const normalizedLabel = getShiftLetterFromTime(startTime, label) || label;
+
           scheduleData.push({
             date: dateStr,
-            label: label.trim(),
+            label: normalizedLabel.trim(),
+            rawLabel: label.trim(),
             time: time.trim(),
             person: normalizedPerson,
             role,

--- a/src/lib/shiftgen/sync.ts
+++ b/src/lib/shiftgen/sync.ts
@@ -131,6 +131,9 @@ export class ShiftGenSyncService {
   /**
    * Match scribes with their providers based on date, zone, and time
    * Following the same logic as the Discord bot
+   *
+   * Now uses normalized shift letters (A, B, C, etc.) which are consistent
+   * between scribe and provider schedules thanks to getShiftLetterFromTime()
    */
   private matchScribesWithProviders(shifts: RawShiftData[]): RawShiftData[] {
     const matchedShifts: RawShiftData[] = [];
@@ -151,6 +154,7 @@ export class ShiftGenSyncService {
       for (let j = 0; j < shifts.length; j++) {
         const other = shifts[j];
 
+        // Must be same date
         if (other.date !== shift.date) continue;
 
         if (isPaShift && other.role === 'MLP') {
@@ -161,7 +165,8 @@ export class ShiftGenSyncService {
             break;
           }
         } else if (other.role === 'Physician') {
-          // For regular shifts, match physicians by exact zone+time match
+          // For regular shifts, match physicians by normalized shift letter AND time
+          // Both scribe and physician schedules now have normalized labels (A, B, C, etc.)
           if (other.time === shift.time && other.label === shift.label) {
             matchingProvider = other;
             processedIndices.add(j);


### PR DESCRIPTION
…atching

- Fix zone mappings: A/E/I → Zone 2, B/F/X → Zone 1 (per user specs)
- Add SHIFT_DEFINITIONS with standard times for each shift letter
- Add getShiftLetterFromTime() to normalize shifts from any schedule format
- Parser now normalizes both scribe and provider shifts to standard letters
- This fixes provider matching which was failing due to label mismatches
- Example: scribe 'A' and physician 'SJH A' both normalize to 'A' → match works