### PR TITLE
fix: change RailwayZoneGroups from interface to type

### DIFF
--- a/src/components/calendar/RailwayScheduleCalendar.tsx
+++ b/src/components/calendar/RailwayScheduleCalendar.tsx
@@ -14,9 +14,9 @@ interface RailwayShiftData {
   providerRole: string | null;
 }
 
-interface RailwayZoneGroups {
+type RailwayZoneGroups = {
   [K in ZoneGroup]?: RailwayShiftData[];
-}
+};
 
 interface RailwayDailyData {
   success: boolean;


### PR DESCRIPTION
## Summary
- Fix TypeScript compilation error preventing deployment
- Change RailwayZoneGroups from interface to type alias

## The Problem

After merging PR #169, the build failed with:
```
Error: Expected ']', got 'in'
```

**Root Cause:**
Line 18 of `RailwayScheduleCalendar.tsx` used mapped type syntax `[K in ZoneGroup]?` within an interface, which is not valid TypeScript. Mapped types can only be used in type aliases, not interfaces.

## The Fix

Changed from:
```typescript
interface RailwayZoneGroups {
  [K in ZoneGroup]?: RailwayShiftData[];
}
```

To:
```typescript
type RailwayZoneGroups = {
  [K in ZoneGroup]?: RailwayShiftData[];
};
```

## Changes
- `src/components/calendar/RailwayScheduleCalendar.tsx:17-19` - Changed interface to type alias

## Technical Note
TypeScript only allows mapped types in type aliases because interfaces require statically known property names at declaration time, whereas mapped types dynamically generate properties based on a union type.