### PR TITLE
fix: calendar not displaying shifts from Railway database

### DIFF
--- a/app/api/railway-shifts/daily/route.ts
+++ b/app/api/railway-shifts/daily/route.ts
@@ -38,12 +38,13 @@ export async function GET(request: NextRequest) {
     console.log(`[Railway API] Sample shift:`, shifts[0]);
 
     // Group shifts by zone
-    const zoneGroups: Record<string, any[]> = {};
-
-    // Initialize zone groups
-    Object.keys(ZONE_CONFIGS).forEach(zone => {
-      zoneGroups[zone] = [];
-    });
+    const zoneGroups: Record<string, any[]> = {
+      zone1: [],
+      zone2: [],
+      zones34: [],
+      zones56: [],
+      overflowPit: [],
+    };
 
     // Separate scribes and providers (case-insensitive)
     const scribes = shifts.filter(s => s.role.toLowerCase() === 'scribe');


### PR DESCRIPTION
## Summary
- Fix critical bug where calendar showed "No shifts scheduled" despite database having data
- Initialize zone groups with correct keys in daily API endpoint
- Add detailed debug logging for troubleshooting