### PR TITLE
fix: center calendar circles with justify-items-center

### DIFF
--- a/src/components/calendar/RailwayScheduleCalendar.tsx
+++ b/src/components/calendar/RailwayScheduleCalendar.tsx
@@ -328,7 +328,7 @@ export default function RailwayScheduleCalendar() {
                   </div>
                 ))}
               </div>
-              <div className="grid grid-cols-7 gap-1">
+              <div className="grid grid-cols-7 gap-1 justify-items-center">
                 {Array.from({ length: startingDayOfWeek }).map((_, i) => (
                   <div key={`empty-${i}`} className="w-10 h-10" />
                 ))}
@@ -430,7 +430,7 @@ export default function RailwayScheduleCalendar() {
               </div>
             ))}
           </div>
-          <div className="grid grid-cols-7 gap-1">
+          <div className="grid grid-cols-7 gap-1 justify-items-center">
             {emptyDays.map((i) => (
               <div key={`empty-${i}`} className="w-10 h-10" />
             ))}


### PR DESCRIPTION
- Add justify-items-center to calendar grid containers
- Fixes left-shift alignment issue with date circles
- Applied to both locked preview and unlocked calendar views