### PR TITLE
Update page styling to match Medications/Terminology layout

### DIFF
--- a/app/procedures/ProceduresPageClient.tsx
+++ b/app/procedures/ProceduresPageClient.tsx
@@ -88,13 +88,15 @@ export default function ProceduresPageClient({
 
   return (
     <div className="min-h-screen">
-      <div className="max-w-7xl mx-auto px-6 py-16">
+      <div className="max-w-7xl mx-auto px-6 py-12">
         {/* Header Section */}
-        <div className="mb-12 text-center">
-          <h1 className="text-5xl font-semibold tracking-tight text-gray-900 dark:text-white mb-3">
-            ED Procedures
-          </h1>
-          <p className="text-lg text-gray-600 dark:text-gray-400 font-normal max-w-2xl mx-auto">
+        <div className="mb-10">
+          <div className="flex items-center gap-3 mb-3">
+            <h1 className="text-4xl font-semibold tracking-tight text-gray-900 dark:text-white">
+              ED Procedures
+            </h1>
+          </div>
+          <p className="text-lg text-gray-600 dark:text-gray-400 font-normal">
             Documentation guide for ED procedures
           </p>
         </div>

--- a/app/providers/ProvidersPageClient.tsx
+++ b/app/providers/ProvidersPageClient.tsx
@@ -105,13 +105,15 @@ export default function ProvidersPageClient({
 
   return (
     <div className="min-h-screen">
-      <div className="max-w-7xl mx-auto px-6 py-16">
+      <div className="max-w-7xl mx-auto px-6 py-12">
         {/* Header Section */}
-        <div className="mb-12 text-center">
-          <h1 className="text-5xl font-semibold tracking-tight text-gray-900 dark:text-white mb-3">
-            Providers
-          </h1>
-          <p className="text-lg text-gray-600 dark:text-gray-400 font-normal max-w-2xl mx-auto">
+        <div className="mb-10">
+          <div className="flex items-center gap-3 mb-3">
+            <h1 className="text-4xl font-semibold tracking-tight text-gray-900 dark:text-white">
+              Providers
+            </h1>
+          </div>
+          <p className="text-lg text-gray-600 dark:text-gray-400 font-normal">
             Discover provider preferences and documentation expectations
           </p>
         </div>

--- a/app/scenarios/ScenariosPageClient.tsx
+++ b/app/scenarios/ScenariosPageClient.tsx
@@ -83,13 +83,15 @@ export default function ScenariosPageClient({
 
   return (
     <div className="min-h-screen">
-      <div className="max-w-7xl mx-auto px-6 py-16">
+      <div className="max-w-7xl mx-auto px-6 py-12">
         {/* Header Section */}
-        <div className="mb-12 text-center">
-          <h1 className="text-5xl font-semibold tracking-tight text-gray-900 dark:text-white mb-3">
-            ED Scenarios
-          </h1>
-          <p className="text-lg text-gray-600 dark:text-gray-400 font-normal max-w-2xl mx-auto">
+        <div className="mb-10">
+          <div className="flex items-center gap-3 mb-3">
+            <h1 className="text-4xl font-semibold tracking-tight text-gray-900 dark:text-white">
+              ED Scenarios
+            </h1>
+          </div>
+          <p className="text-lg text-gray-600 dark:text-gray-400 font-normal">
             Browse scenario walkthroughs for various ED events
           </p>
         </div>

--- a/app/smartphrases/SmartPhrasesPageClient.tsx
+++ b/app/smartphrases/SmartPhrasesPageClient.tsx
@@ -105,13 +105,15 @@ export default function SmartPhrasesPageClient({
 
   return (
     <div className="min-h-screen">
-      <div className="max-w-7xl mx-auto px-6 py-16">
+      <div className="max-w-7xl mx-auto px-6 py-12">
         {/* Header Section */}
-        <div className="mb-12 text-center">
-          <h1 className="text-5xl font-semibold tracking-tight text-gray-900 dark:text-white mb-3">
-            SmartPhrase Library
-          </h1>
-          <p className="text-lg text-gray-600 dark:text-gray-400 font-normal max-w-2xl mx-auto">
+        <div className="mb-10">
+          <div className="flex items-center gap-3 mb-3">
+            <h1 className="text-4xl font-semibold tracking-tight text-gray-900 dark:text-white">
+              SmartPhrase Library
+            </h1>
+          </div>
+          <p className="text-lg text-gray-600 dark:text-gray-400 font-normal">
             Browse and search SmartPhrases (.phrases) for more efficient documentation
           </p>
         </div>

--- a/src/components/workspace/WorkspaceSidebarClient.tsx
+++ b/src/components/workspace/WorkspaceSidebarClient.tsx
@@ -41,7 +41,6 @@ export function WorkspaceSidebar() {
               : 'border-transparent text-dim hover:text-main hover:border-white/30 dark:hover:border-white/30'
           )}
         >
-          <FileText size={18} />
           <span>Home</span>
         </Link>
 


### PR DESCRIPTION
- Changed title alignment from center to left on Providers, Procedures, Smart Phrases, and Scenarios pages
- Reduced title size from text-5xl to text-4xl for consistency
- Updated padding and spacing to match reference pages
- Removed FileText icon from Home link in sidebar navigation