### PR TITLE
fix: handle JSON content properly in scenario search filter

### DIFF
--- a/app/scenarios/ScenariosPageClient.tsx
+++ b/app/scenarios/ScenariosPageClient.tsx
@@ -43,7 +43,7 @@ export default function ScenariosPageClient({
           s.title.toLowerCase().includes(query) ||
           s.category.toLowerCase().includes(query) ||
           s.description?.toLowerCase().includes(query) ||
-          s.content.toLowerCase().includes(query) ||
+          JSON.stringify(s.content).toLowerCase().includes(query) ||
           s.tags.some((tag: string) => tag.toLowerCase().includes(query)),
       );
     }


### PR DESCRIPTION
Fixed issue where scenarios were not displaying on the website due to JavaScript error in the search filter. The content field is a JSON object (TipTap format), not a string, so calling .toLowerCase() on it was causing an error. Now properly converting to string with JSON.stringify() before filtering.

Fixes #192