### PR TITLE
fix: Force dynamic rendering for scenarios page to prevent caching

### DIFF
--- a/app/scenarios/page.tsx
+++ b/app/scenarios/page.tsx
@@ -8,6 +8,9 @@ export const metadata: Metadata = {
     'Browse clinical scenario walkthroughs for ED events',
 };
 
+// Force dynamic rendering to prevent caching stale data
+export const dynamic = 'force-dynamic';
+
 export default async function ScenariosPage() {
   // Fetch scenarios with their associated pages (if table exists)
   let scenariosRaw;


### PR DESCRIPTION
Added 'export const dynamic = "force-dynamic"' to the public scenarios page to ensure it always fetches fresh data from the database, matching the behavior of the admin scenarios page. This fixes the issue where scenarios saved in /admin/scenarios were not appearing in /scenarios due to Next.js caching.

Resolves #196