### PR TITLE
fix: Add missing Tiptap extensions to EditorRenderer for scenarios

### DIFF
--- a/src/components/editor/EditorRenderer.tsx
+++ b/src/components/editor/EditorRenderer.tsx
@@ -13,6 +13,8 @@ import Youtube from '@tiptap/extension-youtube';
 import Highlight from '@tiptap/extension-highlight';
 import { TextStyle } from '@tiptap/extension-text-style';
 import Color from '@tiptap/extension-color';
+import { Callout } from './extensions/Callout';
+import { Collapsible } from './extensions/Collapsible';
 
 interface EditorRendererProps {
   content: JSONContent;
@@ -72,6 +74,8 @@ export function EditorRenderer({ content }: EditorRendererProps) {
       }),
       TextStyle,
       Color,
+      Callout,
+      Collapsible,
     ],
     content,
     editable: false,


### PR DESCRIPTION
Added Callout and Collapsible extensions to EditorRenderer to ensure all content created in /admin/scenarios renders properly in /scenarios.

Previously, the TipTapEditor supported callouts and collapsible sections, but EditorRenderer didn't have these extensions registered, causing content with these elements to not display correctly.

Resolves #196