### PR TITLE
fix: resolve TypeScript error in search route

### DIFF
--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { logger } from '@/lib/logger';
 import { searchQuerySchema } from '@/lib/validation/schemas';
+import { Prisma } from '@prisma/client';
 
 export const dynamic = 'force-dynamic';
 
@@ -34,23 +35,18 @@ export async function GET(request: NextRequest) {
       return NextResponse.json([]);
     }
 
-    // Build base filters
-    const baseFilters = {
+    // Build base filters with explicit Prisma types
+    const baseFilters: Prisma.PageWhereInput = {
       deletedAt: null,
       // Exclude orphaned pages
       NOT: {
         OR: [
-          { AND: [{ type: 'PROVIDER' }, { providerId: null }] },
-          { AND: [{ type: 'PROCEDURE' }, { procedureId: null }] },
-          { AND: [{ type: 'SCENARIO' }, { scenarioId: null }] },
-          { AND: [{ type: 'SMARTPHRASE' }, { smartPhraseId: null }] },
-          {
-            AND: [
-              { type: 'PHYSICIAN_DIRECTORY' },
-              { physicianDirectoryId: null },
-            ],
-          },
-          { AND: [{ type: 'MEDICATION' }, { medicationId: null }] },
+          { type: 'PROVIDER', providerId: null },
+          { type: 'PROCEDURE', procedureId: null },
+          { type: 'SCENARIO', scenarioId: null },
+          { type: 'SMARTPHRASE', smartPhraseId: null },
+          { type: 'PHYSICIAN_DIRECTORY', physicianDirectoryId: null },
+          { type: 'MEDICATION', medicationId: null },
         ],
       },
     };


### PR DESCRIPTION
Fixes the TypeScript build error in the search API route from Phase 3 & 4 implementation

## Changes

- Import Prisma namespace from `@prisma/client`
- Explicitly type `baseFilters` as `Prisma.PageWhereInput`
- Simplify orphaned page filter structure (remove unnecessary AND arrays)
- Fix type inference issue where 'type' field was treated as generic string

## Root Cause

TypeScript couldn't infer that the `type` field was a `PageType` enum, treating it as a generic string which doesn't satisfy Prisma's strict type requirements.

Related to #199
