### PR TITLE
Fix calendar PA/MLP provider display and close button styling

### DIFF
--- a/src/components/calendar/RailwayScheduleCalendar.tsx
+++ b/src/components/calendar/RailwayScheduleCalendar.tsx
@@ -116,7 +116,7 @@ function DailyModal({ date, dailyData, onClose }: DailyModalProps) {
           </div>
           <button
             onClick={onClose}
-            className="p-2 hover:opacity-70 transition-opacity"
+            className="p-2 hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-lg transition-colors"
             aria-label="Close"
           >
             <X className="w-5 h-5 text-zinc-600 dark:text-zinc-400" />


### PR DESCRIPTION
- Add time overlap matching for PA shifts (matches Discord bot logic)
- PA scribes and MLPs often have different end times, so exact time matching was failing (e.g., scribe 1000-1830 vs MLP 1000-2000)
- Now PA shifts match MLPs by checking if start times are within 60 minutes
- Fix close button styling: use subtle background hover instead of opacity
- Change from hover:opacity-70 to rounded background for cleaner look

Fixes #204